### PR TITLE
Build release binaries with CGO disabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
         run: make test
       
       - name: Build release binaries
+        env:
+          CGO_ENABLED: "0"
         run: |
           # Build Linux binary
           GOOS=linux GOARCH=amd64 go build -o bin/vault-plugin-secrets-openai ./cmd/vault-plugin-secrets-openai


### PR DESCRIPTION
The current release binaries do not work in Alpine/musl-based environments. Since the official Docker containers provided by Hashicorp _are_ based on Alpine, this means the plugin does not work in Docker-based environments at all.

When trying to set up the plugin, the following happens:

```bash
❯ vault secrets enable -path=openai vault-plugin-secrets-openai
Error enabling: Error making API request.

URL: POST https://mydomain.com:8200/v1/sys/mounts/openai
Code: 400. Errors:

* invalid backend version: 2 errors occurred:
	* fork/exec /usr/local/libexec/vault/vault-plugin-secrets-openai: no such file or directory
	* fork/exec /usr/local/libexec/vault/vault-plugin-secrets-openai: no such file or directory
```

The files are in fact present in the container and are executable. The error message is a bit misleading as it is caused by the fact that the released binaries are dynamically linked against glibc. I verified that the issue disappears if I just build a fully static binary, which does not depend on `glibc` at runtime with this command:

```bash
❯ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/vault-plugin-secrets-openai
```

I see that there is a `build-release` Make target, but that only builds linux binaries and it is not used in the GitHub release workflow, so I just added `CGO_ENABLED=0` to the build step.