### PR TITLE
security: address accepted findings from PR #7 (SSRF, data race, panic, rotation, hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ Configure the OpenAI secrets engine with admin API credentials.
 - `admin_api_key_id` (string, required) - Admin API key ID for OpenAI  
 - `organization_id` (string, required) - Organization ID for OpenAI
 - `api_endpoint` (string, optional) - URL for the OpenAI API (default: `https://api.openai.com/v1`)
-- `allow_private_endpoint` (bool, optional) - Allow `api_endpoint` to target a private or link-local address (default: `false`). Enable only when pointing the plugin at a trusted internal OpenAI-compatible proxy.
 - `rotation_period` (duration, optional) - Period between automatic admin API key rotations
 - `rotation_window` (duration, optional) - Window during which rotation can occur
 - `disable_automated_rotation` (bool, optional) - Disable automated rotation of admin credentials
@@ -131,12 +130,22 @@ vault write openai/config \
   rotation_period=604800
 ```
 
-**Network egress and service mesh**
+**Network egress control**
 
-The plugin validates `api_endpoint` at config time and re-checks the resolved IP at connection time to mitigate Server-Side Request Forgery (SSRF). By default it rejects connections to private or link-local addresses. These checks apply only to the plugin's outbound calls to the OpenAI API; they do not affect Vault's own cluster, storage, or mesh traffic.
+The plugin validates that `api_endpoint` is a valid `http` or `https` URL with a hostname. It does not enforce network egress policy. If you need to restrict where this plugin can connect, use Vault ACL parameter constraints and network controls such as firewall, security group, or service mesh egress policy.
 
-- With a transparent service mesh sidecar (for example Istio, Consul, or Linkerd using iptables or eBPF redirection) and the public `https://api.openai.com/v1` endpoint, no configuration change is needed. The plugin dials the public address, which is allowed, and the sidecar redirects it transparently.
-- If `api_endpoint` targets an in-mesh address (for example a Kubernetes ClusterIP or a `*.svc.cluster.local` name that resolves to an RFC1918 range), or if an outbound `HTTP(S)_PROXY` on a private address is used, set `allow_private_endpoint=true` so the plugin can reach it.
+For example, you can pin `api_endpoint` to the public OpenAI API with `allowed_parameters`:
+
+```hcl
+path "openai/config" {
+  capabilities = ["create", "update"]
+
+  allowed_parameters = {
+    "api_endpoint" = ["https://api.openai.com/v1"]
+    "*"            = []
+  }
+}
+```
 
 #### Read configuration
 ```
@@ -148,7 +157,6 @@ Read the current configuration. Sensitive fields are not returned.
 - `api_endpoint` - The configured API endpoint
 - `organization_id` - The organization ID
 - `admin_api_key_id` - The admin API key ID
-- `allow_private_endpoint` - Whether private/link-local endpoints are permitted
 - `rotation_period` - Automatic rotation period (if enabled)
 - `rotation_window` - Rotation window (if enabled)
 - `last_rotated` - Last rotation timestamp (if automated rotation is enabled)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ vault write openai/config \
   rotation_period=604800
 ```
 
+**Network egress and service mesh**
+
+The plugin validates `api_endpoint` at config time and re-checks the resolved IP at connection time to mitigate Server-Side Request Forgery (SSRF). By default it rejects connections to private or link-local addresses. These checks apply only to the plugin's outbound calls to the OpenAI API; they do not affect Vault's own cluster, storage, or mesh traffic.
+
+- With a transparent service mesh sidecar (for example Istio, Consul, or Linkerd using iptables or eBPF redirection) and the public `https://api.openai.com/v1` endpoint, no configuration change is needed. The plugin dials the public address, which is allowed, and the sidecar redirects it transparently.
+- If `api_endpoint` targets an in-mesh address (for example a Kubernetes ClusterIP or a `*.svc.cluster.local` name that resolves to an RFC1918 range), or if an outbound `HTTP(S)_PROXY` on a private address is used, set `allow_private_endpoint=true` so the plugin can reach it.
+
 #### Read configuration
 ```
 GET /openai/config

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Configure the OpenAI secrets engine with admin API credentials.
 - `admin_api_key_id` (string, required) - Admin API key ID for OpenAI  
 - `organization_id` (string, required) - Organization ID for OpenAI
 - `api_endpoint` (string, optional) - URL for the OpenAI API (default: `https://api.openai.com/v1`)
+- `allow_private_endpoint` (bool, optional) - Allow `api_endpoint` to target a private or link-local address (default: `false`). Enable only when pointing the plugin at a trusted internal OpenAI-compatible proxy.
 - `rotation_period` (duration, optional) - Period between automatic admin API key rotations
 - `rotation_window` (duration, optional) - Window during which rotation can occur
 - `disable_automated_rotation` (bool, optional) - Disable automated rotation of admin credentials
@@ -140,6 +141,7 @@ Read the current configuration. Sensitive fields are not returned.
 - `api_endpoint` - The configured API endpoint
 - `organization_id` - The organization ID
 - `admin_api_key_id` - The admin API key ID
+- `allow_private_endpoint` - Whether private/link-local endpoints are permitted
 - `rotation_period` - Automatic rotation period (if enabled)
 - `rotation_window` - Rotation window (if enabled)
 - `last_rotated` - Last rotation timestamp (if automated rotation is enabled)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ vault write openai/config \
 
 **Network egress control**
 
-The plugin validates that `api_endpoint` is a valid `http` or `https` URL with a hostname. It does not enforce network egress policy. If you need to restrict where this plugin can connect, use Vault ACL parameter constraints and network controls such as firewall, security group, or service mesh egress policy.
+The plugin validates that `api_endpoint` is a valid `http` or `https` URL with a host, which can be a hostname or an IP address. It does not enforce network egress policy. If you need to restrict where this plugin can connect, use Vault ACL parameter constraints and network controls such as firewall, security group, or service mesh egress policy.
 
 For example, you can pin `api_endpoint` to the public OpenAI API with `allowed_parameters`:
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Create or update a role definition for generating dynamic credentials.
 **Parameters:**
 - `name` (string, required) - Name of the role
 - `project_id` (string, required) - OpenAI Project ID (e.g., `proj_abc123`)
-- `service_account_name_template` (string, optional) - Template for service account names (default: `vault-{{.RoleName}}-{{.RandomSuffix}}`)
+- `service_account_name_template` (string, optional) - [Vault username template](https://developer.hashicorp.com/vault/docs/concepts/username-templating) for service account names (default: `vault-{{.RoleName}}-{{.RandomSuffix}}`). The template receives `RoleName`, `RandomSuffix`, and `ProjectName`.
 - `service_account_description` (string, optional) - Description for service accounts (default: `Service account created by Vault`)
 - `ttl` (duration, optional) - Default TTL for API keys (default: `1h`)
 - `max_ttl` (duration, optional) - Maximum TTL for API keys (default: `24h`)

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/cryptoutil v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.3 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
+github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w45CtbWDNvGqWp/R3Ng=
+github.com/hashicorp/go-secure-stdlib/base62 v0.1.2/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
 github.com/hashicorp/go-secure-stdlib/cryptoutil v0.1.1 h1:VaLXp47MqD1Y2K6QVrA9RooQiPyCgAbnfeJg44wKuJk=
 github.com/hashicorp/go-secure-stdlib/cryptoutil v0.1.1/go.mod h1:hH8rgXHh9fPSDPerG6WzABHsHF+9ZpLhRI1LPk4JZ8c=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.3 h1:kH3Rhiht36xhAfhuHyWJDgdXXEx9IIZhDGRk24CDhzg=
@@ -177,6 +179,7 @@ github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25L
 github.com/hashicorp/go-sockaddr v1.0.7 h1:G+pTkSO01HpR5qCxg7lxfsFEZaG+C0VssTy/9dbT+Fw=
 github.com/hashicorp/go-sockaddr v1.0.7/go.mod h1:FZQbEYa1pxkQ7WLpyXJ6cbjpT8q0YgQaK/JakXqGyWw=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -92,10 +92,9 @@ func Backend(client ClientAPI) *backend {
 	}
 
 	b := &backend{
-		client:       client,
-		roleLocks:    locksutil.CreateLocks(),
-		managedUsers: make(map[string]struct{}),
-		logger:       logger,
+		client:    client,
+		roleLocks: locksutil.CreateLocks(),
+		logger:    logger,
 	}
 
 	b.Backend = &framework.Backend{
@@ -160,7 +159,9 @@ func (b *backend) initialize(ctx context.Context, initRequest *logical.Initializ
 		if err != nil {
 			return err
 		}
+		b.Lock()
 		b.client = client
+		b.Unlock()
 	}
 
 	return nil
@@ -185,10 +186,7 @@ type backend struct {
 	// issues with the priority queue.
 	roleLocks []*locksutil.LockEntry
 
-	// managedUsers contains the set of OpenAI service accounts managed by the secrets engine
-	// This is used to ensure that service accounts are not duplicated.
-	managedUsers map[string]struct{}
-	storageView  logical.Storage
+	storageView logical.Storage
 }
 
 // Logger returns the backend's logger

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -61,13 +61,23 @@ func NewClient(adminAPIKey string, logger hclog.Logger) *Client {
 // validation alone leaves open (a hostname that resolves to an internal IP) for
 // direct connections.
 //
-// Limitation: when an outbound proxy is configured via HTTP(S)_PROXY, the
-// dialer connects to the proxy and (for https) tunnels via CONNECT, so the
-// destination IP is resolved by the proxy and is not seen by checkDialAddress.
-// In that deployment the resolved-address guard cannot inspect the real target.
-// Config-write is a privileged operation, so this residual gap is accepted as
-// defense-in-depth rather than a complete control; loopback is always allowed
-// and operators can opt in to private endpoints with allow_private_endpoint.
+// Deployment notes:
+//   - Outbound proxy (HTTP(S)_PROXY): the dialer connects to the proxy, and for
+//     https tunnels the destination via CONNECT. The Control hook therefore
+//     inspects the proxy address, not the real target. This cuts both ways: a
+//     proxy on a public IP lets a private destination through unchecked (a
+//     bypass), while a proxy on a private IP is itself blocked (an over-block).
+//   - Service mesh: with a transparent sidecar (iptables/eBPF redirect), the
+//     dialer still targets the original destination, so a public OpenAI
+//     endpoint is allowed and then transparently redirected to the loopback
+//     sidecar. But if api_endpoint resolves to an in-mesh address (e.g. a
+//     Kubernetes ClusterIP / *.svc.cluster.local, usually RFC1918) the dial is
+//     blocked.
+//
+// In all of the blocked cases above, set allow_private_endpoint=true to permit
+// the private target. Loopback is always allowed. Because config-write is a
+// privileged operation, the residual proxy bypass is accepted as
+// defense-in-depth rather than a complete control.
 func (c *Client) guardedTransport() *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -54,6 +55,9 @@ func NewClient(adminAPIKey string, logger hclog.Logger) *Client {
 // plugin connects. Restrict endpoint values with Vault ACL parameter
 // constraints and network egress policy when that matters.
 func validateAPIEndpoint(rawURL string) error {
+	if strings.Contains(rawURL, "#") {
+		return fmt.Errorf("api_endpoint must not include a fragment")
+	}
 	parsed, err := url.ParseRequestURI(rawURL)
 	if err != nil {
 		return fmt.Errorf("api_endpoint is not a valid URL: %w", err)
@@ -67,6 +71,15 @@ func validateAPIEndpoint(rawURL string) error {
 	host := parsed.Hostname()
 	if host == "" {
 		return fmt.Errorf("api_endpoint must include a host")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("api_endpoint must not include userinfo")
+	}
+	if parsed.RawQuery != "" {
+		return fmt.Errorf("api_endpoint must not include a query string")
+	}
+	if parsed.Fragment != "" {
+		return fmt.Errorf("api_endpoint must not include a fragment")
 	}
 	return nil
 }

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -9,7 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"syscall"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -28,32 +31,137 @@ const (
 
 // Client represents an OpenAI API client
 type Client struct {
-	httpClient     *http.Client
-	apiEndpoint    string
-	adminAPIKey    string
-	adminAPIKeyID  string
-	organizationID string
-	logger         hclog.Logger
+	httpClient           *http.Client
+	apiEndpoint          string
+	adminAPIKey          string
+	adminAPIKeyID        string
+	organizationID       string
+	allowPrivateEndpoint bool
+	logger               hclog.Logger
 }
 
 // NewClient creates a new OpenAI client
 func NewClient(adminAPIKey string, logger hclog.Logger) *Client {
-	return &Client{
-		httpClient:     &http.Client{Timeout: 30 * time.Second},
+	c := &Client{
 		apiEndpoint:    DefaultAPIEndpoint,
 		adminAPIKey:    adminAPIKey,
 		organizationID: "", // Will be set through SetConfig
 		logger:         logger,
 	}
+	c.httpClient = &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: c.guardedTransport(),
+	}
+	return c
+}
+
+// guardedTransport returns an http.Transport whose dialer rejects connections
+// to private or link-local IP addresses at dial time. The check runs after DNS
+// resolution against the resolved address, which closes the gap that hostname
+// validation alone leaves open (a hostname that resolves to an internal IP).
+// Loopback is always allowed for local test/mock servers, and operators can opt
+// in to private endpoints by setting allow_private_endpoint.
+func (c *Client) guardedTransport() *http.Transport {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			return c.checkDialAddress(address)
+		},
+	}
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// checkDialAddress rejects a resolved dial address that targets a private or
+// link-local IP, unless it is loopback or private endpoints are explicitly
+// allowed.
+func (c *Client) checkDialAddress(address string) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || ip.IsLoopback() {
+		return nil
+	}
+	if c.allowPrivateEndpoint {
+		return nil
+	}
+	if isBlockedIP(ip) {
+		return fmt.Errorf("connection to private or link-local address %s is not allowed", ip)
+	}
+	return nil
+}
+
+// isBlockedIP reports whether an IP is in a range that should not be reachable
+// from the plugin by default (RFC1918 private, link-local, or unspecified).
+func isBlockedIP(ip net.IP) bool {
+	return ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified()
+}
+
+// validateAPIEndpoint checks that the supplied endpoint URL is safe to use.
+//
+// Rules:
+//   - Must be a valid URL with a non-empty hostname.
+//   - http is permitted only for loopback (127.0.0.1, ::1, localhost) so local
+//     test/mock servers work while plaintext credential transmission to remote
+//     hosts is blocked.
+//   - IP-literal endpoints in private or link-local ranges are rejected to
+//     prevent Server-Side Request Forgery (SSRF), unless allowPrivate is set.
+//
+// Hostname endpoints that resolve to private ranges are caught at dial time by
+// checkDialAddress; this function provides fast feedback at config-write time.
+func validateAPIEndpoint(rawURL string, allowPrivate bool) error {
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return fmt.Errorf("api_endpoint is not a valid URL: %w", err)
+	}
+	switch parsed.Scheme {
+	case "https", "http":
+		// handled below
+	default:
+		return fmt.Errorf("api_endpoint must use https (got %q)", parsed.Scheme)
+	}
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("api_endpoint must include a hostname")
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		if parsed.Scheme == "http" && !ip.IsLoopback() {
+			return fmt.Errorf("api_endpoint with http scheme is only allowed for loopback addresses (127.0.0.1, ::1)")
+		}
+		if !ip.IsLoopback() && !allowPrivate && isBlockedIP(ip) {
+			return fmt.Errorf("api_endpoint must not target a private or link-local IP address; set allow_private_endpoint=true to override")
+		}
+		return nil
+	}
+
+	if parsed.Scheme == "http" && hostname != "localhost" {
+		return fmt.Errorf("api_endpoint with http scheme is only allowed for loopback addresses (use localhost or 127.0.0.1)")
+	}
+	return nil
 }
 
 // Config contains configuration for the OpenAI client
 // Add AdminAPIKeyID to track the key's ID for revocation
 type Config struct {
-	AdminAPIKey    string `json:"admin_api_key"`
-	AdminAPIKeyID  string `json:"admin_api_key_id,omitempty"`
-	APIEndpoint    string `json:"api_endpoint"`
-	OrganizationID string `json:"organization_id"`
+	AdminAPIKey          string `json:"admin_api_key"`
+	AdminAPIKeyID        string `json:"admin_api_key_id,omitempty"`
+	APIEndpoint          string `json:"api_endpoint"`
+	OrganizationID       string `json:"organization_id"`
+	AllowPrivateEndpoint bool   `json:"allow_private_endpoint,omitempty"`
 }
 
 // ServiceAccount represents an OpenAI project service account
@@ -148,8 +256,12 @@ func (c *Client) SetConfig(config *Config) error {
 	c.adminAPIKey = config.AdminAPIKey
 	c.adminAPIKeyID = config.AdminAPIKeyID
 	c.organizationID = config.OrganizationID
+	c.allowPrivateEndpoint = config.AllowPrivateEndpoint
 
 	if config.APIEndpoint != "" {
+		if err := validateAPIEndpoint(config.APIEndpoint, config.AllowPrivateEndpoint); err != nil {
+			return err
+		}
 		c.apiEndpoint = config.APIEndpoint
 	}
 
@@ -192,7 +304,10 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 		}
 	}()
 
-	respBody, err := io.ReadAll(resp.Body)
+	// Limit the response body to 1 MiB to prevent memory exhaustion from
+	// oversized or malicious responses.
+	const maxResponseBytes = 1 << 20 // 1 MiB
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -233,13 +348,19 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 			return nil, fmt.Errorf("%s", errMsg)
 		}
 
-		// Fallback for non-standard error format
-		c.logger.Error("OpenAI API non-standard error",
+		// Fallback for non-standard error format. Log a truncated body at debug
+		// level to avoid leaking organization IDs or account metadata into logs
+		// and the audit trail, and keep the raw body out of the returned error.
+		preview := string(respBody)
+		if len(preview) > 200 {
+			preview = preview[:200] + "...[truncated]"
+		}
+		c.logger.Debug("OpenAI API non-standard error",
 			"status", resp.StatusCode,
-			"body", string(respBody),
+			"body_preview", preview,
 			"method", method,
 			"path", path)
-		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("API error (%d) from OpenAI", resp.StatusCode)
 	}
 
 	return respBody, nil

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -58,9 +58,16 @@ func NewClient(adminAPIKey string, logger hclog.Logger) *Client {
 // guardedTransport returns an http.Transport whose dialer rejects connections
 // to private or link-local IP addresses at dial time. The check runs after DNS
 // resolution against the resolved address, which closes the gap that hostname
-// validation alone leaves open (a hostname that resolves to an internal IP).
-// Loopback is always allowed for local test/mock servers, and operators can opt
-// in to private endpoints by setting allow_private_endpoint.
+// validation alone leaves open (a hostname that resolves to an internal IP) for
+// direct connections.
+//
+// Limitation: when an outbound proxy is configured via HTTP(S)_PROXY, the
+// dialer connects to the proxy and (for https) tunnels via CONNECT, so the
+// destination IP is resolved by the proxy and is not seen by checkDialAddress.
+// In that deployment the resolved-address guard cannot inspect the real target.
+// Config-write is a privileged operation, so this residual gap is accepted as
+// defense-in-depth rather than a complete control; loopback is always allowed
+// and operators can opt in to private endpoints with allow_private_endpoint.
 func (c *Client) guardedTransport() *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -64,9 +64,9 @@ func validateAPIEndpoint(rawURL string) error {
 	default:
 		return fmt.Errorf("api_endpoint must use http or https (got %q)", parsed.Scheme)
 	}
-	hostname := parsed.Hostname()
-	if hostname == "" {
-		return fmt.Errorf("api_endpoint must include a hostname")
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("api_endpoint must include a host")
 	}
 	return nil
 }

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -9,10 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
-	"syscall"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -31,115 +29,31 @@ const (
 
 // Client represents an OpenAI API client
 type Client struct {
-	httpClient           *http.Client
-	apiEndpoint          string
-	adminAPIKey          string
-	adminAPIKeyID        string
-	organizationID       string
-	allowPrivateEndpoint bool
-	logger               hclog.Logger
+	httpClient     *http.Client
+	apiEndpoint    string
+	adminAPIKey    string
+	adminAPIKeyID  string
+	organizationID string
+	logger         hclog.Logger
 }
 
 // NewClient creates a new OpenAI client
 func NewClient(adminAPIKey string, logger hclog.Logger) *Client {
-	c := &Client{
+	return &Client{
+		httpClient:     &http.Client{Timeout: 30 * time.Second},
 		apiEndpoint:    DefaultAPIEndpoint,
 		adminAPIKey:    adminAPIKey,
 		organizationID: "", // Will be set through SetConfig
 		logger:         logger,
 	}
-	c.httpClient = &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: c.guardedTransport(),
-	}
-	return c
 }
 
-// guardedTransport returns an http.Transport whose dialer rejects connections
-// to private or link-local IP addresses at dial time. The check runs after DNS
-// resolution against the resolved address, which closes the gap that hostname
-// validation alone leaves open (a hostname that resolves to an internal IP) for
-// direct connections.
-//
-// Deployment notes:
-//   - Outbound proxy (HTTP(S)_PROXY): the dialer connects to the proxy, and for
-//     https tunnels the destination via CONNECT. The Control hook therefore
-//     inspects the proxy address, not the real target. This cuts both ways: a
-//     proxy on a public IP lets a private destination through unchecked (a
-//     bypass), while a proxy on a private IP is itself blocked (an over-block).
-//   - Service mesh: with a transparent sidecar (iptables/eBPF redirect), the
-//     dialer still targets the original destination, so a public OpenAI
-//     endpoint is allowed and then transparently redirected to the loopback
-//     sidecar. But if api_endpoint resolves to an in-mesh address (e.g. a
-//     Kubernetes ClusterIP / *.svc.cluster.local, usually RFC1918) the dial is
-//     blocked.
-//
-// In all of the blocked cases above, set allow_private_endpoint=true to permit
-// the private target. Loopback is always allowed. Because config-write is a
-// privileged operation, the residual proxy bypass is accepted as
-// defense-in-depth rather than a complete control.
-func (c *Client) guardedTransport() *http.Transport {
-	dialer := &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		Control: func(_, address string, _ syscall.RawConn) error {
-			return c.checkDialAddress(address)
-		},
-	}
-	return &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           dialer.DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-}
-
-// checkDialAddress rejects a resolved dial address that targets a private or
-// link-local IP, unless it is loopback or private endpoints are explicitly
-// allowed.
-func (c *Client) checkDialAddress(address string) error {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		host = address
-	}
-	ip := net.ParseIP(host)
-	if ip == nil || ip.IsLoopback() {
-		return nil
-	}
-	if c.allowPrivateEndpoint {
-		return nil
-	}
-	if isBlockedIP(ip) {
-		return fmt.Errorf("connection to private or link-local address %s is not allowed", ip)
-	}
-	return nil
-}
-
-// isBlockedIP reports whether an IP is in a range that should not be reachable
-// from the plugin by default (RFC1918 private, link-local, or unspecified).
-func isBlockedIP(ip net.IP) bool {
-	return ip.IsPrivate() ||
-		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified()
-}
-
-// validateAPIEndpoint checks that the supplied endpoint URL is safe to use.
-//
-// Rules:
-//   - Must be a valid URL with a non-empty hostname.
-//   - http is permitted only for loopback (127.0.0.1, ::1, localhost) so local
-//     test/mock servers work while plaintext credential transmission to remote
-//     hosts is blocked.
-//   - IP-literal endpoints in private or link-local ranges are rejected to
-//     prevent Server-Side Request Forgery (SSRF), unless allowPrivate is set.
-//
-// Hostname endpoints that resolve to private ranges are caught at dial time by
-// checkDialAddress; this function provides fast feedback at config-write time.
-func validateAPIEndpoint(rawURL string, allowPrivate bool) error {
+// validateAPIEndpoint performs a fail-fast syntax check for api_endpoint at
+// config-write time. It deliberately does not implement SSRF policy: an
+// operator with write access to openai/config is already choosing where the
+// plugin connects. Restrict endpoint values with Vault ACL parameter
+// constraints and network egress policy when that matters.
+func validateAPIEndpoint(rawURL string) error {
 	parsed, err := url.ParseRequestURI(rawURL)
 	if err != nil {
 		return fmt.Errorf("api_endpoint is not a valid URL: %w", err)
@@ -148,25 +62,11 @@ func validateAPIEndpoint(rawURL string, allowPrivate bool) error {
 	case "https", "http":
 		// handled below
 	default:
-		return fmt.Errorf("api_endpoint must use https (got %q)", parsed.Scheme)
+		return fmt.Errorf("api_endpoint must use http or https (got %q)", parsed.Scheme)
 	}
 	hostname := parsed.Hostname()
 	if hostname == "" {
 		return fmt.Errorf("api_endpoint must include a hostname")
-	}
-
-	if ip := net.ParseIP(hostname); ip != nil {
-		if parsed.Scheme == "http" && !ip.IsLoopback() {
-			return fmt.Errorf("api_endpoint with http scheme is only allowed for loopback addresses (127.0.0.1, ::1)")
-		}
-		if !ip.IsLoopback() && !allowPrivate && isBlockedIP(ip) {
-			return fmt.Errorf("api_endpoint must not target a private or link-local IP address; set allow_private_endpoint=true to override")
-		}
-		return nil
-	}
-
-	if parsed.Scheme == "http" && hostname != "localhost" {
-		return fmt.Errorf("api_endpoint with http scheme is only allowed for loopback addresses (use localhost or 127.0.0.1)")
 	}
 	return nil
 }
@@ -174,11 +74,10 @@ func validateAPIEndpoint(rawURL string, allowPrivate bool) error {
 // Config contains configuration for the OpenAI client
 // Add AdminAPIKeyID to track the key's ID for revocation
 type Config struct {
-	AdminAPIKey          string `json:"admin_api_key"`
-	AdminAPIKeyID        string `json:"admin_api_key_id,omitempty"`
-	APIEndpoint          string `json:"api_endpoint"`
-	OrganizationID       string `json:"organization_id"`
-	AllowPrivateEndpoint bool   `json:"allow_private_endpoint,omitempty"`
+	AdminAPIKey    string `json:"admin_api_key"`
+	AdminAPIKeyID  string `json:"admin_api_key_id,omitempty"`
+	APIEndpoint    string `json:"api_endpoint"`
+	OrganizationID string `json:"organization_id"`
 }
 
 // ServiceAccount represents an OpenAI project service account
@@ -273,10 +172,9 @@ func (c *Client) SetConfig(config *Config) error {
 	c.adminAPIKey = config.AdminAPIKey
 	c.adminAPIKeyID = config.AdminAPIKeyID
 	c.organizationID = config.OrganizationID
-	c.allowPrivateEndpoint = config.AllowPrivateEndpoint
 
 	if config.APIEndpoint != "" {
-		if err := validateAPIEndpoint(config.APIEndpoint, config.AllowPrivateEndpoint); err != nil {
+		if err := validateAPIEndpoint(config.APIEndpoint); err != nil {
 			return err
 		}
 		c.apiEndpoint = config.APIEndpoint

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -84,3 +84,20 @@ func (b *backend) ensureClientConfigured(ctx context.Context, storage logical.St
 	b.client = client
 	return nil
 }
+
+// configuredClient returns a stable client snapshot or an explicit error if
+// configuration was deleted between the lazy-initialization check and the read
+// lock snapshot.
+func (b *backend) configuredClient(ctx context.Context, storage logical.Storage) (ClientAPI, error) {
+	if err := b.ensureClientConfigured(ctx, storage); err != nil {
+		return nil, err
+	}
+
+	b.RLock()
+	client := b.client
+	b.RUnlock()
+	if client == nil {
+		return nil, fmt.Errorf("OpenAI is not configured")
+	}
+	return client, nil
+}

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -46,10 +46,11 @@ func (b *backend) configureClientFromStorage(ctx context.Context, storage logica
 
 	client := NewClient(config.AdminAPIKey, b.Logger())
 	clientConfig := &Config{
-		AdminAPIKey:    config.AdminAPIKey,
-		AdminAPIKeyID:  config.AdminAPIKeyID,
-		APIEndpoint:    config.APIEndpoint,
-		OrganizationID: config.OrganizationID,
+		AdminAPIKey:          config.AdminAPIKey,
+		AdminAPIKeyID:        config.AdminAPIKeyID,
+		APIEndpoint:          config.APIEndpoint,
+		OrganizationID:       config.OrganizationID,
+		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
 	}
 
 	if err := client.SetConfig(clientConfig); err != nil {
@@ -59,15 +60,28 @@ func (b *backend) configureClientFromStorage(ctx context.Context, storage logica
 	return client, nil
 }
 
-// ensureClientConfigured ensures the backend has a configured client
-// This is used in multiple places to lazy-load the client when needed
+// ensureClientConfigured ensures the backend has a configured client.
+// It uses double-checked locking so only one goroutine initializes the client
+// when it is nil, while concurrent callers read it safely.
 func (b *backend) ensureClientConfigured(ctx context.Context, storage logical.Storage) error {
-	if b.client == nil {
-		client, err := b.configureClientFromStorage(ctx, storage)
-		if err != nil {
-			return err
-		}
-		b.client = client
+	// Fast path: client already set.
+	b.RLock()
+	hasClient := b.client != nil
+	b.RUnlock()
+	if hasClient {
+		return nil
 	}
+
+	// Slow path: acquire the write lock and re-check before initializing.
+	b.Lock()
+	defer b.Unlock()
+	if b.client != nil {
+		return nil
+	}
+	client, err := b.configureClientFromStorage(ctx, storage)
+	if err != nil {
+		return err
+	}
+	b.client = client
 	return nil
 }

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -46,11 +46,10 @@ func (b *backend) configureClientFromStorage(ctx context.Context, storage logica
 
 	client := NewClient(config.AdminAPIKey, b.Logger())
 	clientConfig := &Config{
-		AdminAPIKey:          config.AdminAPIKey,
-		AdminAPIKeyID:        config.AdminAPIKeyID,
-		APIEndpoint:          config.APIEndpoint,
-		OrganizationID:       config.OrganizationID,
-		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
+		AdminAPIKey:    config.AdminAPIKey,
+		AdminAPIKeyID:  config.AdminAPIKeyID,
+		APIEndpoint:    config.APIEndpoint,
+		OrganizationID: config.OrganizationID,
 	}
 
 	if err := client.SetConfig(clientConfig); err != nil {

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -329,15 +329,11 @@ func (b *backend) validateProject(ctx context.Context, s logical.Storage, projec
 		return nil, fmt.Errorf("project ID is required")
 	}
 
-	// Ensure client is configured
-	if err := b.ensureClientConfigured(ctx, s); err != nil {
+	// Validate project with OpenAI API
+	client, err := b.configuredClient(ctx, s)
+	if err != nil {
 		return nil, err
 	}
-
-	// Validate project with OpenAI API
-	b.RLock()
-	client := b.client
-	b.RUnlock()
 	projectInfo, err := client.GetProject(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("OpenAI project validation failed: %w", err)

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -277,8 +277,10 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 
 // pathConfigDelete deletes the configuration
 func (b *backend) pathConfigDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	// Deregister any active rotation job before removing the config so Vault's
-	// rotation manager does not keep firing against a missing configuration.
+	// Deregister any rotation job associated with this config before removing the
+	// stored configuration. Rotation jobs are managed separately from plugin
+	// storage, so leaving one registered could cause later rotation attempts to
+	// run after the config is gone.
 	config, err := getConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -21,11 +21,12 @@ const (
 // openaiConfig contains the configuration for the OpenAI secrets engine
 // Only supports the current OpenAI API model and automated rotation.
 type openaiConfig struct {
-	AdminAPIKey     string    `json:"admin_api_key"`
-	AdminAPIKeyID   string    `json:"admin_api_key_id"`
-	APIEndpoint     string    `json:"api_endpoint"`
-	OrganizationID  string    `json:"organization_id"`
-	LastRotatedTime time.Time `json:"last_rotated_time"`
+	AdminAPIKey          string    `json:"admin_api_key"`
+	AdminAPIKeyID        string    `json:"admin_api_key_id"`
+	APIEndpoint          string    `json:"api_endpoint"`
+	OrganizationID       string    `json:"organization_id"`
+	AllowPrivateEndpoint bool      `json:"allow_private_endpoint"`
+	LastRotatedTime      time.Time `json:"last_rotated_time"`
 
 	// Automated rotation configuration
 	automatedrotationutil.AutomatedRotationParams
@@ -79,6 +80,11 @@ func (b *backend) pathAdminConfig() []*framework.Path {
 						Description: "URL to the OpenAI API. Defaults to https://api.openai.com/v1",
 						Default:     DefaultAPIEndpoint,
 					},
+					"allow_private_endpoint": {
+						Type:        framework.TypeBool,
+						Description: "Allow api_endpoint to target a private or link-local address. Defaults to false. Enable only when pointing the plugin at a trusted internal OpenAI-compatible proxy.",
+						Default:     false,
+					},
 				}
 				// Add the automated rotation fields
 				automatedrotationutil.AddAutomatedRotationFields(fields)
@@ -127,9 +133,10 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data
 	}
 
 	respData := map[string]interface{}{
-		"api_endpoint":     config.APIEndpoint,
-		"organization_id":  config.OrganizationID,
-		"admin_api_key_id": config.AdminAPIKeyID,
+		"api_endpoint":           config.APIEndpoint,
+		"organization_id":        config.OrganizationID,
+		"admin_api_key_id":       config.AdminAPIKeyID,
+		"allow_private_endpoint": config.AllowPrivateEndpoint,
 	}
 
 	// Add automated rotation parameters to the response
@@ -195,6 +202,10 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 		config.APIEndpoint = DefaultAPIEndpoint
 	}
 
+	if allowPrivate, ok := data.GetOk("allow_private_endpoint"); ok {
+		config.AllowPrivateEndpoint = allowPrivate.(bool)
+	}
+
 	// Parse automated rotation parameters
 	if err := config.ParseAutomatedRotationFields(data); err != nil {
 		return logical.ErrorResponse("error parsing automated rotation fields: %s", err), nil
@@ -208,10 +219,11 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	// Create a test client to validate the configuration
 	client := NewClient(config.AdminAPIKey, b.Logger())
 	clientConfig := &Config{
-		AdminAPIKey:    config.AdminAPIKey,
-		AdminAPIKeyID:  config.AdminAPIKeyID,
-		APIEndpoint:    config.APIEndpoint,
-		OrganizationID: config.OrganizationID,
+		AdminAPIKey:          config.AdminAPIKey,
+		AdminAPIKeyID:        config.AdminAPIKeyID,
+		APIEndpoint:          config.APIEndpoint,
+		OrganizationID:       config.OrganizationID,
+		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
 	}
 
 	if err := client.SetConfig(clientConfig); err != nil {
@@ -267,19 +279,40 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 		return nil, wrappedError
 	}
 
-	// Update backend client
+	// Update backend client under the write lock.
+	b.Lock()
 	b.client = client
+	b.Unlock()
 
 	return nil, nil
 }
 
 // pathConfigDelete deletes the configuration
 func (b *backend) pathConfigDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	err := req.Storage.Delete(ctx, configPath)
-	if err == nil {
-		b.client = nil
+	// Deregister any active rotation job before removing the config so Vault's
+	// rotation manager does not keep firing against a missing configuration.
+	config, err := getConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	if config != nil && config.ShouldRegisterRotationJob() {
+		deregisterReq := &rotation.RotationJobDeregisterRequest{
+			MountPoint: req.MountPoint,
+			ReqPath:    req.Path,
+		}
+		b.Logger().Debug("Deregistering rotation job during config delete", "mount", req.MountPoint+req.Path)
+		if err := b.System().DeregisterRotationJob(ctx, deregisterReq); err != nil {
+			b.Logger().Warn("failed to deregister rotation job during config delete", "error", err)
+		}
+	}
+
+	if err := req.Storage.Delete(ctx, configPath); err != nil {
+		return nil, err
+	}
+	b.Lock()
+	b.client = nil
+	b.Unlock()
+	return nil, nil
 }
 
 // getConfig returns the configuration for this backend
@@ -314,7 +347,10 @@ func (b *backend) validateProject(ctx context.Context, s logical.Storage, projec
 	}
 
 	// Validate project with OpenAI API
-	projectInfo, err := b.client.GetProject(ctx, projectID)
+	b.RLock()
+	client := b.client
+	b.RUnlock()
+	projectInfo, err := client.GetProject(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("OpenAI project validation failed: %w", err)
 	}

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -21,12 +21,11 @@ const (
 // openaiConfig contains the configuration for the OpenAI secrets engine
 // Only supports the current OpenAI API model and automated rotation.
 type openaiConfig struct {
-	AdminAPIKey          string    `json:"admin_api_key"`
-	AdminAPIKeyID        string    `json:"admin_api_key_id"`
-	APIEndpoint          string    `json:"api_endpoint"`
-	OrganizationID       string    `json:"organization_id"`
-	AllowPrivateEndpoint bool      `json:"allow_private_endpoint"`
-	LastRotatedTime      time.Time `json:"last_rotated_time"`
+	AdminAPIKey     string    `json:"admin_api_key"`
+	AdminAPIKeyID   string    `json:"admin_api_key_id"`
+	APIEndpoint     string    `json:"api_endpoint"`
+	OrganizationID  string    `json:"organization_id"`
+	LastRotatedTime time.Time `json:"last_rotated_time"`
 
 	// Automated rotation configuration
 	automatedrotationutil.AutomatedRotationParams
@@ -80,11 +79,6 @@ func (b *backend) pathAdminConfig() []*framework.Path {
 						Description: "URL to the OpenAI API. Defaults to https://api.openai.com/v1",
 						Default:     DefaultAPIEndpoint,
 					},
-					"allow_private_endpoint": {
-						Type:        framework.TypeBool,
-						Description: "Allow api_endpoint to target a private or link-local address. Defaults to false. Enable only when pointing the plugin at a trusted internal OpenAI-compatible proxy.",
-						Default:     false,
-					},
 				}
 				// Add the automated rotation fields
 				automatedrotationutil.AddAutomatedRotationFields(fields)
@@ -133,10 +127,9 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data
 	}
 
 	respData := map[string]interface{}{
-		"api_endpoint":           config.APIEndpoint,
-		"organization_id":        config.OrganizationID,
-		"admin_api_key_id":       config.AdminAPIKeyID,
-		"allow_private_endpoint": config.AllowPrivateEndpoint,
+		"api_endpoint":     config.APIEndpoint,
+		"organization_id":  config.OrganizationID,
+		"admin_api_key_id": config.AdminAPIKeyID,
 	}
 
 	// Add automated rotation parameters to the response
@@ -202,10 +195,6 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 		config.APIEndpoint = DefaultAPIEndpoint
 	}
 
-	if allowPrivate, ok := data.GetOk("allow_private_endpoint"); ok {
-		config.AllowPrivateEndpoint = allowPrivate.(bool)
-	}
-
 	// Parse automated rotation parameters
 	if err := config.ParseAutomatedRotationFields(data); err != nil {
 		return logical.ErrorResponse("error parsing automated rotation fields: %s", err), nil
@@ -219,11 +208,10 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	// Create a test client to validate the configuration
 	client := NewClient(config.AdminAPIKey, b.Logger())
 	clientConfig := &Config{
-		AdminAPIKey:          config.AdminAPIKey,
-		AdminAPIKeyID:        config.AdminAPIKeyID,
-		APIEndpoint:          config.APIEndpoint,
-		OrganizationID:       config.OrganizationID,
-		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
+		AdminAPIKey:    config.AdminAPIKey,
+		AdminAPIKeyID:  config.AdminAPIKeyID,
+		APIEndpoint:    config.APIEndpoint,
+		OrganizationID: config.OrganizationID,
 	}
 
 	if err := client.SetConfig(clientConfig); err != nil {

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -6,6 +6,7 @@ package openaisecrets
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -15,8 +16,13 @@ import (
 )
 
 const (
-	configPath = "config"
+	configPath        = "config"
+	adminAPIKeyPrefix = "sk-admin"
 )
+
+func hasExpectedAdminAPIKeyPrefix(key string) bool {
+	return strings.HasPrefix(key, adminAPIKeyPrefix)
+}
 
 // openaiConfig contains the configuration for the OpenAI secrets engine
 // Only supports the current OpenAI API model and automated rotation.
@@ -163,6 +169,10 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	adminAPIKey, ok := data.GetOk("admin_api_key")
 	if ok {
 		config.AdminAPIKey = adminAPIKey.(string)
+		if !hasExpectedAdminAPIKeyPrefix(config.AdminAPIKey) {
+			b.Logger().Warn("configured admin_api_key does not use the expected OpenAI admin key prefix",
+				"expected_prefix", adminAPIKeyPrefix)
+		}
 	}
 
 	adminAPIKeyID, ok := data.GetOk("admin_api_key_id")

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -4,9 +4,12 @@
 package openaisecrets
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
@@ -134,4 +137,39 @@ func TestConfig_AdminConfig_CRUD(t *testing.T) {
 	}, &framework.FieldData{})
 	require.NoError(t, err)
 	require.Nil(t, resp)
+}
+
+func TestConfigWrite_WarnsWhenAdminKeyPrefixUnexpected(t *testing.T) {
+	b := getTestBackend(t)
+	var logs bytes.Buffer
+	b.logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Warn,
+		Output: &logs,
+	})
+
+	storage := &logical.InmemStorage{}
+	ctx := context.Background()
+	const unexpectedKey = "sk-project-not-admin"
+
+	resp, err := b.pathConfigWrite(ctx, &logical.Request{
+		Storage:    storage,
+		MountPoint: "openai/",
+		Path:       "config",
+	}, &framework.FieldData{
+		Raw: map[string]interface{}{
+			"admin_api_key":    unexpectedKey,
+			"admin_api_key_id": "test-admin-key-id",
+			"organization_id":  "org-123",
+			"api_endpoint":     "https://api.test.com/v1",
+			"rotation_period":  0,
+		},
+		Schema: b.pathAdminConfig()[1].Fields,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	logOutput := logs.String()
+	assert.Contains(t, logOutput, "configured admin_api_key does not use the expected OpenAI admin key prefix")
+	assert.Contains(t, logOutput, adminAPIKeyPrefix)
+	assert.False(t, strings.Contains(logOutput, unexpectedKey), "admin API key value must not be logged")
 }

--- a/plugin/path_dynamic_creds.go
+++ b/plugin/path_dynamic_creds.go
@@ -189,7 +189,11 @@ func (b *backend) pathRoleWrite(ctx context.Context, req *logical.Request, data 
 	role.ProjectID = projectID
 
 	if serviceAccountNameTemplate, ok := data.GetOk("service_account_name_template"); ok {
-		role.ServiceAccountNameTemplate = serviceAccountNameTemplate.(string)
+		tmplStr := serviceAccountNameTemplate.(string)
+		if err := validateNameTemplate(tmplStr); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+		role.ServiceAccountNameTemplate = tmplStr
 	} else if role.ServiceAccountNameTemplate == "" {
 		role.ServiceAccountNameTemplate = "vault-{{.RoleName}}-{{.RandomSuffix}}"
 	}
@@ -346,26 +350,20 @@ func (b *backend) pathCredsCreate(ctx context.Context, req *logical.Request, dat
 		}
 	}
 
-	// Calculate expiry time
-	expiresAt := time.Now().Add(ttl)
-
 	// Create service account (which automatically creates an API key in OpenAI API)
 	b.Logger().Debug("Creating service account with API key", "name", svcAccountName, "project", projectInfo.ID)
-	svcAccount, apiKey, err := b.client.CreateServiceAccount(ctx, projectInfo.ID, CreateServiceAccountRequest{
+	b.RLock()
+	client := b.client
+	b.RUnlock()
+	svcAccount, apiKey, err := client.CreateServiceAccount(ctx, projectInfo.ID, CreateServiceAccountRequest{
 		Name: svcAccountName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating service account: %w", err)
 	}
 
-	// Note: In OpenAI API, we can't control the TTL of API keys created with service accounts
-	// We'll track the TTL in Vault's system for credential revocation
-
-	// Store service account info for cleanup
-	if err := b.storeServiceAccountInfo(ctx, req.Storage, apiKey.ID, svcAccount.ID, expiresAt); err != nil {
-		b.Logger().Error("failed to store service account mapping", "error", err)
-		// Continue anyway, as the credentials are still valid
-	}
+	// Note: In OpenAI API we cannot control the TTL of API keys created with
+	// service accounts; Vault's lease TTL is used for revocation scheduling.
 
 	// Generate the response
 	resp := b.Secret(dynamicSecretCredsType).Response(map[string]interface{}{
@@ -384,34 +382,6 @@ func (b *backend) pathCredsCreate(ctx context.Context, req *logical.Request, dat
 	resp.Secret.MaxTTL = role.MaxTTL
 
 	return resp, nil
-}
-
-// apiKeyMapping stores the relationship between API keys and service accounts
-type apiKeyMapping struct {
-	APIKeyID         string    `json:"api_key_id"`
-	ServiceAccountID string    `json:"service_account_id"`
-	ExpiresAt        time.Time `json:"expires_at"`
-}
-
-// storeServiceAccountInfo stores the mapping between an API key and its service account
-func (b *backend) storeServiceAccountInfo(ctx context.Context, s logical.Storage, apiKeyID, serviceAccountID string, expiresAt time.Time) error {
-	mapping := apiKeyMapping{
-		APIKeyID:         apiKeyID,
-		ServiceAccountID: serviceAccountID,
-		ExpiresAt:        expiresAt,
-	}
-
-	entry, err := logical.StorageEntryJSON(apiKeyMappingPath(apiKeyID), mapping)
-	if err != nil {
-		return err
-	}
-
-	return s.Put(ctx, entry)
-}
-
-// apiKeyMappingPath returns the storage path for an API key mapping
-func apiKeyMappingPath(apiKeyID string) string {
-	return fmt.Sprintf("api_keys/%s", apiKeyID)
 }
 
 // Secret structure that represents a dynamically generated API key
@@ -443,9 +413,18 @@ func dynamicSecretCreds(b *backend) *framework.Secret {
 
 // dynamicCredsRevoke revokes the API key and deletes the service account
 func (b *backend) dynamicCredsRevoke(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	apiKeyID := req.Secret.InternalData["api_key_id"].(string)
-	serviceAccountID := req.Secret.InternalData["service_account_id"].(string)
-	projectID := req.Secret.InternalData["project_id"].(string)
+	apiKeyID, ok := req.Secret.InternalData["api_key_id"].(string)
+	if !ok || apiKeyID == "" {
+		return nil, fmt.Errorf("internal error: api_key_id missing or not a string in lease internal data")
+	}
+	serviceAccountID, ok := req.Secret.InternalData["service_account_id"].(string)
+	if !ok || serviceAccountID == "" {
+		return nil, fmt.Errorf("internal error: service_account_id missing or not a string in lease internal data")
+	}
+	projectID, ok := req.Secret.InternalData["project_id"].(string)
+	if !ok || projectID == "" {
+		return nil, fmt.Errorf("internal error: project_id missing or not a string in lease internal data")
+	}
 
 	b.Logger().Debug("revoking API key for service Account", "service_account_id", serviceAccountID)
 
@@ -455,14 +434,11 @@ func (b *backend) dynamicCredsRevoke(ctx context.Context, req *logical.Request, 
 	}
 
 	// Delete the service account
-	if err := b.client.DeleteServiceAccount(ctx, serviceAccountID, projectID); err != nil {
+	b.RLock()
+	client := b.client
+	b.RUnlock()
+	if err := client.DeleteServiceAccount(ctx, serviceAccountID, projectID); err != nil {
 		return nil, fmt.Errorf("error deleting service account: %w", err)
-	}
-
-	// Delete the API key mapping
-	if err := req.Storage.Delete(ctx, apiKeyMappingPath(apiKeyID)); err != nil {
-		b.Logger().Error("error deleting API key from storage for service account ID", "service_account_id", serviceAccountID, "error", err)
-		// This is not a fatal error, so continue
 	}
 
 	return nil, nil
@@ -470,7 +446,7 @@ func (b *backend) dynamicCredsRevoke(ctx context.Context, req *logical.Request, 
 
 // Helper functions
 
-// formatName formats a name template with the provided data
+// formatName formats a name template with the provided data.
 func formatName(templateStr string, data map[string]interface{}) (string, error) {
 	tmpl, err := template.New("name").Parse(templateStr)
 	if err != nil {
@@ -485,19 +461,57 @@ func formatName(templateStr string, data map[string]interface{}) (string, error)
 	return buf.String(), nil
 }
 
-// generateRandomString generates a random string of the specified length
+// validateNameTemplate checks that a service-account name template parses,
+// renders with placeholder values, and produces a valid name after
+// sanitization. It runs at role-write time so a broken template is rejected
+// before it can fail at credential-issue time.
+func validateNameTemplate(templateStr string) error {
+	if templateStr == "" {
+		return fmt.Errorf("service_account_name_template must not be empty")
+	}
+	placeholder := map[string]interface{}{
+		"RoleName":     "testrole",
+		"RandomSuffix": "abcdefgh",
+		"ProjectName":  "testproject",
+	}
+	result, err := formatName(templateStr, placeholder)
+	if err != nil {
+		return fmt.Errorf("service_account_name_template is invalid: %w", err)
+	}
+	result = SanitizeServiceAccountName(result)
+	if err := ValidateServiceAccountName(result); err != nil {
+		return fmt.Errorf("service_account_name_template produces an invalid name %q: %w", result, err)
+	}
+	return nil
+}
+
+// generateRandomString generates a cryptographically random string of the
+// specified length. It uses rejection sampling to avoid the modular bias a
+// simple b%len(charset) would introduce when len(charset) does not evenly
+// divide 256.
 func generateRandomString(length int) (string, error) {
 	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const charsetLen = len(charset) // 36
+	// Largest multiple of charsetLen that fits in a byte; bytes at or above this
+	// threshold are discarded to keep the distribution uniform.
+	threshold := 256 - (256 % charsetLen) // 252
+
 	result := make([]byte, length)
-
-	randomBytes := make([]byte, length)
-	_, err := rand.Read(randomBytes)
-	if err != nil {
-		return "", fmt.Errorf("error generating random bytes: %w", err)
-	}
-
-	for i, b := range randomBytes {
-		result[i] = charset[int(b)%len(charset)]
+	buf := make([]byte, length*2) // over-allocate to reduce rand.Read calls
+	written := 0
+	for written < length {
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("error generating random bytes: %w", err)
+		}
+		for _, b := range buf {
+			if written == length {
+				break
+			}
+			if int(b) < threshold {
+				result[written] = charset[int(b)%charsetLen]
+				written++
+			}
+		}
 	}
 
 	return string(result), nil

--- a/plugin/path_dynamic_creds.go
+++ b/plugin/path_dynamic_creds.go
@@ -4,14 +4,13 @@
 package openaisecrets
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"fmt"
-	"text/template"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
+	sdktemplate "github.com/hashicorp/vault/sdk/helper/template"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -440,19 +439,17 @@ func (b *backend) dynamicCredsRevoke(ctx context.Context, req *logical.Request, 
 
 // Helper functions
 
-// formatName formats a name template with the provided data.
+// formatName formats a name template with Vault's username templating helper.
 func formatName(templateStr string, data map[string]interface{}) (string, error) {
-	tmpl, err := template.New("name").Parse(templateStr)
+	tmpl, err := sdktemplate.NewTemplate(sdktemplate.Template(templateStr))
 	if err != nil {
 		return "", fmt.Errorf("invalid template: %w", err)
 	}
-
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
+	result, err := tmpl.Generate(data)
+	if err != nil {
 		return "", fmt.Errorf("error executing template: %w", err)
 	}
-
-	return buf.String(), nil
+	return result, nil
 }
 
 // validateNameTemplate checks that a service-account name template parses,

--- a/plugin/path_dynamic_creds.go
+++ b/plugin/path_dynamic_creds.go
@@ -310,8 +310,8 @@ func (b *backend) pathCredsCreate(ctx context.Context, req *logical.Request, dat
 		return logical.ErrorResponse("project_id %q does not exist", role.ProjectID), nil
 	}
 
-	// Initialize the client if it hasn't been
-	if err := b.ensureClientConfigured(ctx, req.Storage); err != nil {
+	client, err := b.configuredClient(ctx, req.Storage)
+	if err != nil {
 		return logical.ErrorResponse("OpenAI configuration error: %s", err.Error()), nil
 	}
 
@@ -352,9 +352,6 @@ func (b *backend) pathCredsCreate(ctx context.Context, req *logical.Request, dat
 
 	// Create service account (which automatically creates an API key in OpenAI API)
 	b.Logger().Debug("Creating service account with API key", "name", svcAccountName, "project", projectInfo.ID)
-	b.RLock()
-	client := b.client
-	b.RUnlock()
 	svcAccount, apiKey, err := client.CreateServiceAccount(ctx, projectInfo.ID, CreateServiceAccountRequest{
 		Name: svcAccountName,
 	})
@@ -428,15 +425,12 @@ func (b *backend) dynamicCredsRevoke(ctx context.Context, req *logical.Request, 
 
 	b.Logger().Debug("revoking API key for service Account", "service_account_id", serviceAccountID)
 
-	// Initialize the client if it hasn't been
-	if err := b.ensureClientConfigured(ctx, req.Storage); err != nil {
+	client, err := b.configuredClient(ctx, req.Storage)
+	if err != nil {
 		return logical.ErrorResponse("OpenAI configuration error: %s", err.Error()), nil
 	}
 
 	// Delete the service account
-	b.RLock()
-	client := b.client
-	b.RUnlock()
 	if err := client.DeleteServiceAccount(ctx, serviceAccountID, projectID); err != nil {
 		return nil, fmt.Errorf("error deleting service account: %w", err)
 	}

--- a/plugin/path_dynamic_creds_test.go
+++ b/plugin/path_dynamic_creds_test.go
@@ -5,6 +5,7 @@ package openaisecrets
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -32,7 +33,7 @@ func TestFormatName(t *testing.T) {
 			hasError: false,
 		},
 		{
-			name:     "complex template",
+			name:     "complex field template",
 			template: "vault-{{.RoleName}}-{{.RandomSuffix}}-{{.ProjectName}}",
 			data: map[string]interface{}{
 				"RoleName":     "test",
@@ -40,6 +41,25 @@ func TestFormatName(t *testing.T) {
 				"ProjectName":  "proj1",
 			},
 			expected: "vault-test-abc123-proj1",
+			hasError: false,
+		},
+		{
+			name:     "vault username template truncate function",
+			template: "vault-{{.RoleName | truncate 4}}-{{.RandomSuffix}}",
+			data: map[string]interface{}{
+				"RoleName":     "testingrole",
+				"RandomSuffix": "abc123",
+			},
+			expected: "vault-test-abc123",
+			hasError: false,
+		},
+		{
+			name:     "vault username template random function",
+			template: "vault-{{.RoleName}}-{{random 8}}",
+			data: map[string]interface{}{
+				"RoleName": "test",
+			},
+			expected: "",
 			hasError: false,
 		},
 		{
@@ -61,7 +81,11 @@ func TestFormatName(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
+				if strings.Contains(tt.template, "{{random") {
+					assert.Regexp(t, `^vault-test-[A-Za-z0-9]{8}$`, result)
+				} else {
+					assert.Equal(t, tt.expected, result)
+				}
 			}
 		})
 	}

--- a/plugin/rotation.go
+++ b/plugin/rotation.go
@@ -42,10 +42,9 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 	// Create a new client with the existing admin API key
 	oldClient := NewClient(config.AdminAPIKey, b.Logger())
 	oldClientConfig := &Config{
-		AdminAPIKey:          config.AdminAPIKey,
-		APIEndpoint:          config.APIEndpoint,
-		OrganizationID:       config.OrganizationID,
-		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
+		AdminAPIKey:    config.AdminAPIKey,
+		APIEndpoint:    config.APIEndpoint,
+		OrganizationID: config.OrganizationID,
 	}
 
 	if err := oldClient.SetConfig(oldClientConfig); err != nil {
@@ -93,10 +92,9 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 	// Test the new key
 	newClient := NewClient(newAdminKey, b.Logger())
 	newClientConfig := &Config{
-		AdminAPIKey:          newAdminKey,
-		APIEndpoint:          config.APIEndpoint,
-		OrganizationID:       config.OrganizationID,
-		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
+		AdminAPIKey:    newAdminKey,
+		APIEndpoint:    config.APIEndpoint,
+		OrganizationID: config.OrganizationID,
 	}
 
 	if err := newClient.SetConfig(newClientConfig); err != nil {

--- a/plugin/rotation.go
+++ b/plugin/rotation.go
@@ -137,17 +137,22 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 	// manually revoke it, and prevents the next rotation from treating the new
 	// key ID as the one to revoke. A per-ID path ensures that a second
 	// consecutive failure does not overwrite a previously recorded stale key.
+	//
+	// The key ID is persisted in Vault storage (encrypted by the barrier) and is
+	// deliberately not written to logs in clear text, to avoid leaking sensitive
+	// credential metadata into the log/audit trail.
 	if oldAdminKeyID != "" {
 		b.Logger().Debug("Cleaning up previous admin API key")
 		if err := newClient.RevokeAdminAPIKey(ctx, oldAdminKeyID); err != nil {
-			b.Logger().Error("Failed to revoke previous admin key - the key may still be active in OpenAI",
-				"old_key_id", oldAdminKeyID, "error", err)
 			if putErr := storage.Put(ctx, &logical.StorageEntry{
 				Key:   pendingRevocationPath(oldAdminKeyID),
 				Value: []byte(oldAdminKeyID),
 			}); putErr != nil {
-				b.Logger().Error("Failed to record stale admin key for manual cleanup",
-					"old_key_id", oldAdminKeyID, "error", putErr)
+				b.Logger().Error("Failed to revoke previous admin key and failed to record it for manual cleanup; the key may still be active in OpenAI",
+					"error", err, "record_error", putErr)
+			} else {
+				b.Logger().Error("Failed to revoke previous admin key; recorded under storage path rotation/pending_revocation/ for manual cleanup; the key may still be active in OpenAI",
+					"error", err)
 			}
 			return false, err
 		}

--- a/plugin/rotation.go
+++ b/plugin/rotation.go
@@ -15,6 +15,13 @@ import (
 // Core Rotation Implementation
 //------------------------------------------------------------------------------
 
+// pendingRevocationPath returns the storage path used to record an admin key ID
+// that could not be revoked during rotation, keyed per ID so concurrent or
+// consecutive failures do not overwrite each other.
+func pendingRevocationPath(keyID string) string {
+	return fmt.Sprintf("rotation/pending_revocation/%s", keyID)
+}
+
 // rotateAdminAPIKey rotates the admin API key
 func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage) (bool, error) {
 	// Get the existing configuration
@@ -126,16 +133,17 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 
 	// Revoke the previous key now that the new one is confirmed and persisted.
 	// If revocation fails, the new key is already in storage, so record the
-	// stale key ID under a dedicated storage key. This lets an operator find
-	// and manually revoke it, and prevents the next rotation from treating the
-	// new key ID as the one to revoke.
+	// stale key ID under a per-ID storage path. This lets an operator find and
+	// manually revoke it, and prevents the next rotation from treating the new
+	// key ID as the one to revoke. A per-ID path ensures that a second
+	// consecutive failure does not overwrite a previously recorded stale key.
 	if oldAdminKeyID != "" {
 		b.Logger().Debug("Cleaning up previous admin API key")
 		if err := newClient.RevokeAdminAPIKey(ctx, oldAdminKeyID); err != nil {
 			b.Logger().Error("Failed to revoke previous admin key - the key may still be active in OpenAI",
 				"old_key_id", oldAdminKeyID, "error", err)
 			if putErr := storage.Put(ctx, &logical.StorageEntry{
-				Key:   "rotation/pending_revocation",
+				Key:   pendingRevocationPath(oldAdminKeyID),
 				Value: []byte(oldAdminKeyID),
 			}); putErr != nil {
 				b.Logger().Error("Failed to record stale admin key for manual cleanup",

--- a/plugin/rotation.go
+++ b/plugin/rotation.go
@@ -35,9 +35,10 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 	// Create a new client with the existing admin API key
 	oldClient := NewClient(config.AdminAPIKey, b.Logger())
 	oldClientConfig := &Config{
-		AdminAPIKey:    config.AdminAPIKey,
-		APIEndpoint:    config.APIEndpoint,
-		OrganizationID: config.OrganizationID,
+		AdminAPIKey:          config.AdminAPIKey,
+		APIEndpoint:          config.APIEndpoint,
+		OrganizationID:       config.OrganizationID,
+		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
 	}
 
 	if err := oldClient.SetConfig(oldClientConfig); err != nil {
@@ -50,8 +51,14 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 
 	// Try up to 3 times with exponential backoff
 	for attempt := 1; attempt <= 3; attempt++ {
+		// Use a random suffix for the key name so rotation timing is not
+		// disclosed to anyone who can list admin API keys in the OpenAI console.
+		keyNameSuffix, randErr := generateRandomString(8)
+		if randErr != nil {
+			keyNameSuffix = fmt.Sprintf("r%d", attempt) // safe fallback
+		}
 		b.Logger().Debug("Creating new admin API key", "attempt", attempt)
-		newAdminKey, newAdminKeyID, createErr = oldClient.CreateAdminAPIKey(ctx, fmt.Sprintf("vault-rotated-admin-key-%d", time.Now().Unix()))
+		newAdminKey, newAdminKeyID, createErr = oldClient.CreateAdminAPIKey(ctx, fmt.Sprintf("vault-admin-key-%s", keyNameSuffix))
 
 		if createErr == nil && newAdminKey != "" && newAdminKeyID != "" {
 			break
@@ -79,9 +86,10 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 	// Test the new key
 	newClient := NewClient(newAdminKey, b.Logger())
 	newClientConfig := &Config{
-		AdminAPIKey:    newAdminKey,
-		APIEndpoint:    config.APIEndpoint,
-		OrganizationID: config.OrganizationID,
+		AdminAPIKey:          newAdminKey,
+		APIEndpoint:          config.APIEndpoint,
+		OrganizationID:       config.OrganizationID,
+		AllowPrivateEndpoint: config.AllowPrivateEndpoint,
 	}
 
 	if err := newClient.SetConfig(newClientConfig); err != nil {
@@ -110,14 +118,29 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 		return false, err
 	}
 
-	// Update the current client
+	// Update the current client under the write lock so concurrent requests
+	// always see a consistent client reference.
+	b.Lock()
 	b.client = newClient
+	b.Unlock()
 
-	// Clean up the previous key using the new client and previous key ID
+	// Revoke the previous key now that the new one is confirmed and persisted.
+	// If revocation fails, the new key is already in storage, so record the
+	// stale key ID under a dedicated storage key. This lets an operator find
+	// and manually revoke it, and prevents the next rotation from treating the
+	// new key ID as the one to revoke.
 	if oldAdminKeyID != "" {
 		b.Logger().Debug("Cleaning up previous admin API key")
 		if err := newClient.RevokeAdminAPIKey(ctx, oldAdminKeyID); err != nil {
-			b.Logger().Error("Failed to revoke previous admin key", "error", err)
+			b.Logger().Error("Failed to revoke previous admin key - the key may still be active in OpenAI",
+				"old_key_id", oldAdminKeyID, "error", err)
+			if putErr := storage.Put(ctx, &logical.StorageEntry{
+				Key:   "rotation/pending_revocation",
+				Value: []byte(oldAdminKeyID),
+			}); putErr != nil {
+				b.Logger().Error("Failed to record stale admin key for manual cleanup",
+					"old_key_id", oldAdminKeyID, "error", putErr)
+			}
 			return false, err
 		}
 	} else {

--- a/plugin/rotation.go
+++ b/plugin/rotation.go
@@ -15,13 +15,6 @@ import (
 // Core Rotation Implementation
 //------------------------------------------------------------------------------
 
-// pendingRevocationPath returns the storage path used to record an admin key ID
-// that could not be revoked during rotation, keyed per ID so concurrent or
-// consecutive failures do not overwrite each other.
-func pendingRevocationPath(keyID string) string {
-	return fmt.Sprintf("rotation/pending_revocation/%s", keyID)
-}
-
 // rotateAdminAPIKey rotates the admin API key
 func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage) (bool, error) {
 	// Get the existing configuration
@@ -130,28 +123,16 @@ func (b *backend) rotateAdminAPIKey(ctx context.Context, storage logical.Storage
 	b.Unlock()
 
 	// Revoke the previous key now that the new one is confirmed and persisted.
-	// If revocation fails, the new key is already in storage, so record the
-	// stale key ID under a per-ID storage path. This lets an operator find and
-	// manually revoke it, and prevents the next rotation from treating the new
-	// key ID as the one to revoke. A per-ID path ensures that a second
-	// consecutive failure does not overwrite a previously recorded stale key.
-	//
-	// The key ID is persisted in Vault storage (encrypted by the barrier) and is
-	// deliberately not written to logs in clear text, to avoid leaking sensitive
-	// credential metadata into the log/audit trail.
+	// If revocation fails, the new key remains active and stored, while the
+	// previous key may still be active in OpenAI. Do not log the key ID here:
+	// admin key IDs are credential metadata and may be captured by logs or audit
+	// sinks. Deferred retry/cleanup belongs in the bounded-overlap follow-up
+	// design, where records have a proper lifecycle.
 	if oldAdminKeyID != "" {
 		b.Logger().Debug("Cleaning up previous admin API key")
 		if err := newClient.RevokeAdminAPIKey(ctx, oldAdminKeyID); err != nil {
-			if putErr := storage.Put(ctx, &logical.StorageEntry{
-				Key:   pendingRevocationPath(oldAdminKeyID),
-				Value: []byte(oldAdminKeyID),
-			}); putErr != nil {
-				b.Logger().Error("Failed to revoke previous admin key and failed to record it for manual cleanup; the key may still be active in OpenAI",
-					"error", err, "record_error", putErr)
-			} else {
-				b.Logger().Error("Failed to revoke previous admin key; recorded under storage path rotation/pending_revocation/ for manual cleanup; the key may still be active in OpenAI",
-					"error", err)
-			}
+			b.Logger().Error("Failed to revoke previous admin key; the key may still be active in OpenAI",
+				"error", err)
 			return false, err
 		}
 	} else {

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -1,0 +1,390 @@
+// Copyright Ricardo Oliveira 2025.
+// SPDX-License-Identifier: MPL-2.0
+//
+// Regression tests for the security hardening described in the follow-up to
+// https://github.com/gitrgoliveira/vault-plugin-secrets-openai/pull/7
+
+package openaisecrets
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/rotation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Item 1: SSRF / api_endpoint validation
+// ---------------------------------------------------------------------------
+
+func TestValidateAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpoint     string
+		allowPrivate bool
+		wantError    bool
+		errContains  string
+	}{
+		// Valid
+		{"openai production endpoint", "https://api.openai.com/v1", false, false, ""},
+		{"custom https hostname", "https://proxy.example.com/v1", false, false, ""},
+		{"https with port", "https://api.openai.com:443/v1", false, false, ""},
+		{"http loopback by IP", "http://127.0.0.1:8080/v1", false, false, ""},
+		{"http loopback by hostname", "http://localhost:9090/v1", false, false, ""},
+
+		// Invalid scheme
+		{"ftp scheme", "ftp://api.openai.com/v1", false, true, "https"},
+		{"no scheme", "api.openai.com/v1", false, true, "valid URL"},
+
+		// http with non-loopback is rejected
+		{"http public IP", "http://1.2.3.4/v1", false, true, "loopback"},
+		{"http public hostname", "http://api.openai.com/v1", false, true, "loopback"},
+		{"http private IP", "http://10.0.0.1/v1", false, true, "loopback"},
+
+		// SSRF: private / link-local literals
+		{"AWS metadata service", "https://169.254.169.254/latest/meta-data", false, true, "link-local"},
+		{"RFC1918 10.x", "https://10.0.0.1/", false, true, "private"},
+		{"RFC1918 172.16.x", "https://172.16.0.1/", false, true, "private"},
+		{"RFC1918 192.168.x", "https://192.168.1.1/", false, true, "private"},
+		{"IPv6 link-local", "https://[fe80::1]/", false, true, "link-local"},
+
+		// Opt-in override
+		{"private allowed when opted in", "https://10.0.0.1/v1", true, false, ""},
+		{"metadata allowed when opted in", "https://169.254.169.254/", true, false, ""},
+
+		// Malformed
+		{"empty string", "", false, true, "valid URL"},
+		{"just a path", "/v1", false, true, "https"},
+		{"missing hostname", "https:///v1", false, true, "hostname"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAPIEndpoint(tt.endpoint, tt.allowPrivate)
+			if tt.wantError {
+				require.Error(t, err, "expected error for endpoint %q", tt.endpoint)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err, "unexpected error for endpoint %q", tt.endpoint)
+		})
+	}
+}
+
+// TestCheckDialAddress verifies the dial-time guard that closes the gap a
+// hostname-only validation leaves open: a name that resolves to an internal IP.
+func TestCheckDialAddress(t *testing.T) {
+	c := NewClient("k", hclog.NewNullLogger())
+
+	// Private and link-local resolved addresses are rejected by default.
+	for _, addr := range []string{"10.0.0.1:443", "192.168.1.1:443", "169.254.169.254:80", "[fe80::1]:443"} {
+		require.Error(t, c.checkDialAddress(addr), "expected %q to be blocked", addr)
+	}
+
+	// Loopback and public addresses are allowed.
+	for _, addr := range []string{"127.0.0.1:8080", "[::1]:8080", "1.2.3.4:443"} {
+		require.NoError(t, c.checkDialAddress(addr), "expected %q to be allowed", addr)
+	}
+
+	// Opt-in relaxes the guard for private addresses.
+	c.allowPrivateEndpoint = true
+	require.NoError(t, c.checkDialAddress("10.0.0.1:443"))
+}
+
+// TestDialGuard_BlocksPrivateAtTransport drives a real request through the
+// guarded transport to prove the resolved-IP check fires at dial time, even
+// when the endpoint bypassed config-write validation.
+func TestDialGuard_BlocksPrivateAtTransport(t *testing.T) {
+	c := NewClient("k", hclog.NewNullLogger())
+	// Simulate a hostname that resolved to a private IP by assigning the
+	// endpoint directly, bypassing SetConfig validation.
+	c.apiEndpoint = "https://10.0.0.1"
+
+	_, err := c.doRequest(context.Background(), http.MethodGet, "/v1/models", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private or link-local")
+
+	// With the opt-in flag the guard no longer blocks; the request fails for a
+	// different reason (no server listening / timeout), not the SSRF guard. Use
+	// a short context so the unreachable dial does not wait for the full client
+	// timeout.
+	c.allowPrivateEndpoint = true
+	shortCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err = c.doRequest(shortCtx, http.MethodGet, "/v1/models", nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "private or link-local")
+}
+
+// TestSSRF_PrivateEndpointRejectedAtConfig verifies end-to-end rejection at
+// config-write time.
+func TestSSRF_PrivateEndpointRejectedAtConfig(t *testing.T) {
+	b := getTestBackend(t)
+	ctx := context.Background()
+	schema := b.pathAdminConfig()[1].Fields
+
+	for _, ep := range []string{
+		"http://10.0.0.1/v1",
+		"https://192.168.1.1/v1",
+		"https://169.254.169.254/latest/meta-data",
+		"ftp://api.openai.com/v1",
+	} {
+		t.Run(ep, func(t *testing.T) {
+			req := &logical.Request{
+				Operation:  logical.UpdateOperation,
+				Path:       "config",
+				Storage:    &logical.InmemStorage{},
+				MountPoint: TestMountPoint,
+			}
+			fd := &framework.FieldData{
+				Raw: map[string]interface{}{
+					"admin_api_key":    "test-key",
+					"admin_api_key_id": "test-key-id",
+					"organization_id":  "org-123",
+					"api_endpoint":     ep,
+				},
+				Schema: schema,
+			}
+			resp, err := b.pathConfigWrite(ctx, req, fd)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.True(t, resp.IsError(), "expected error response for endpoint %q", ep)
+		})
+	}
+}
+
+// TestConfig_AllowPrivateEndpoint confirms the opt-in flag permits a private
+// endpoint at config-write time.
+func TestConfig_AllowPrivateEndpoint(t *testing.T) {
+	b := getTestBackend(t)
+	ctx := context.Background()
+
+	req := &logical.Request{
+		Operation:  logical.UpdateOperation,
+		Path:       "config",
+		Storage:    &logical.InmemStorage{},
+		MountPoint: TestMountPoint,
+	}
+	fd := &framework.FieldData{
+		Raw: map[string]interface{}{
+			"admin_api_key":          "test-key",
+			"admin_api_key_id":       "test-key-id",
+			"organization_id":        "org-123",
+			"api_endpoint":           "https://10.0.0.1/v1",
+			"allow_private_endpoint": true,
+		},
+		Schema: b.pathAdminConfig()[1].Fields,
+	}
+	resp, err := b.pathConfigWrite(ctx, req, fd)
+	require.NoError(t, err)
+	if resp != nil {
+		assert.False(t, resp.IsError(), "private endpoint should be accepted when opted in")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Item 6: response body size limit
+// ---------------------------------------------------------------------------
+
+func TestResponseBodySizeLimit(t *testing.T) {
+	const maxResponseBytes = 1 << 20
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("a", 2*maxResponseBytes)))
+	}))
+	defer server.Close()
+
+	c := NewClient("k", hclog.NewNullLogger())
+	require.NoError(t, c.SetConfig(&Config{
+		AdminAPIKey:    "k",
+		OrganizationID: "org-123",
+		APIEndpoint:    server.URL,
+	}))
+
+	body, err := c.doRequest(context.Background(), http.MethodGet, "/v1/models", nil)
+	require.NoError(t, err)
+	assert.Len(t, body, maxResponseBytes, "response body should be capped at 1 MiB")
+}
+
+// ---------------------------------------------------------------------------
+// Item 3: safe type assertions in dynamicCredsRevoke
+// ---------------------------------------------------------------------------
+
+func TestDynamicCredsRevoke_MissingInternalData(t *testing.T) {
+	b := getTestBackend(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name     string
+		internal map[string]interface{}
+	}{
+		{"nil internal data", nil},
+		{"missing api_key_id", map[string]interface{}{"service_account_id": "svc", "project_id": "proj"}},
+		{"wrong type service_account_id", map[string]interface{}{"api_key_id": "k", "service_account_id": 42, "project_id": "proj"}},
+		{"empty project_id", map[string]interface{}{"api_key_id": "k", "service_account_id": "svc", "project_id": ""}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &logical.Request{
+				Storage: &logical.InmemStorage{},
+				Secret:  &logical.Secret{InternalData: tc.internal},
+			}
+			// Must return an error, not panic.
+			_, err := b.dynamicCredsRevoke(ctx, req, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "internal error")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Item 7: uniform random distribution
+// ---------------------------------------------------------------------------
+
+func TestGenerateRandomString_NoBias(t *testing.T) {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const samples = 60000
+	const strLen = 10
+
+	counts := make(map[rune]int, len(charset))
+	total := 0
+	for i := 0; i < samples; i++ {
+		s, err := generateRandomString(strLen)
+		require.NoError(t, err)
+		require.Len(t, s, strLen)
+		for _, r := range s {
+			assert.True(t, strings.ContainsRune(charset, r), "unexpected character %q", r)
+			counts[r]++
+			total++
+		}
+	}
+
+	expected := float64(total) / float64(len(charset))
+	for _, r := range charset {
+		dev := math.Abs(float64(counts[r])-expected) / expected
+		assert.Less(t, dev, 0.1, "character %q deviates %.3f from uniform", r, dev)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Item 8: name template validation
+// ---------------------------------------------------------------------------
+
+func TestValidateNameTemplate(t *testing.T) {
+	cases := []struct {
+		name      string
+		template  string
+		wantError bool
+	}{
+		{"default template", "vault-{{.RoleName}}-{{.RandomSuffix}}", false},
+		{"project name template", "{{.ProjectName}}-{{.RandomSuffix}}", false},
+		{"empty template", "", true},
+		{"broken syntax", "vault-{{.RoleName", true},
+		{"reserved word", "openai", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNameTemplate(tc.template)
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRoleWrite_InvalidTemplate(t *testing.T) {
+	b := getTestBackend(t)
+	ctx := context.Background()
+
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "roles/bad",
+		Storage:   &logical.InmemStorage{},
+	}
+	fd := &framework.FieldData{
+		Raw: map[string]interface{}{
+			"name":                          "bad",
+			"project_id":                    TestProjectID,
+			"service_account_name_template": "vault-{{.RoleName",
+		},
+		Schema: b.pathDynamicSvcAccount()[0].Fields,
+	}
+	resp, err := b.pathRoleWrite(ctx, req, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.IsError(), "broken template should be rejected at role-write time")
+}
+
+// ---------------------------------------------------------------------------
+// Item 5: config delete deregisters the rotation job
+// ---------------------------------------------------------------------------
+
+type recordingSystemView struct {
+	logical.StaticSystemView
+	deregisterCalled bool
+}
+
+func (r *recordingSystemView) RegisterRotationJob(_ context.Context, _ *rotation.RotationJobConfigureRequest) (string, error) {
+	return "test-job-id", nil
+}
+
+func (r *recordingSystemView) DeregisterRotationJob(_ context.Context, _ *rotation.RotationJobDeregisterRequest) error {
+	r.deregisterCalled = true
+	return nil
+}
+
+func TestConfigDelete_DeregistersRotationJob(t *testing.T) {
+	sv := &recordingSystemView{
+		StaticSystemView: logical.StaticSystemView{
+			DefaultLeaseTTLVal: defaultTTL,
+			MaxLeaseTTLVal:     maxTTL,
+		},
+	}
+	b := Backend(&mockClient{})
+	cfg := logical.TestBackendConfig()
+	cfg.Logger = hclog.NewNullLogger()
+	cfg.System = sv
+	require.NoError(t, b.Setup(context.Background(), cfg))
+
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+
+	// Persist a config with automated rotation enabled so a job exists.
+	config := &openaiConfig{
+		AdminAPIKey:    "k",
+		AdminAPIKeyID:  "id",
+		OrganizationID: "org-123",
+		APIEndpoint:    DefaultAPIEndpoint,
+	}
+	config.RotationPeriod = 24 * 3600
+	require.True(t, config.ShouldRegisterRotationJob())
+	entry, err := logical.StorageEntryJSON(configPath, config)
+	require.NoError(t, err)
+	require.NoError(t, storage.Put(ctx, entry))
+
+	req := &logical.Request{
+		Operation:  logical.DeleteOperation,
+		Path:       "config",
+		Storage:    storage,
+		MountPoint: TestMountPoint,
+	}
+	_, err = b.pathConfigDelete(ctx, req, nil)
+	require.NoError(t, err)
+	assert.True(t, sv.deregisterCalled, "expected rotation job to be deregistered on config delete")
+}

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -8,6 +8,7 @@ package openaisecrets
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -387,4 +388,68 @@ func TestConfigDelete_DeregistersRotationJob(t *testing.T) {
 	_, err = b.pathConfigDelete(ctx, req, nil)
 	require.NoError(t, err)
 	assert.True(t, sv.deregisterCalled, "expected rotation job to be deregistered on config delete")
+}
+
+// ---------------------------------------------------------------------------
+// Item 4: failed revocation records each stale key under a per-ID path
+// ---------------------------------------------------------------------------
+
+// TestRotation_PendingRevocationPerKey verifies that when admin key revocation
+// fails, the stale key ID is recorded under a per-ID storage path, and that two
+// consecutive failures retain two distinct records rather than overwriting.
+func TestRotation_PendingRevocationPerKey(t *testing.T) {
+	var keyCounter int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/admin_api_keys"):
+			keyCounter++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				`{"object":"admin_api_key","id":"new-key-%d","name":"n","value":"sk-new-%d","created_at":1}`,
+				keyCounter, keyCounter)))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/admin_api_keys"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case r.Method == http.MethodDelete:
+			// Simulate revocation failure.
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	b := getTestBackend(t)
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+
+	config := &openaiConfig{
+		AdminAPIKey:    "old-secret",
+		AdminAPIKeyID:  "old-key-1",
+		OrganizationID: "org-123",
+		APIEndpoint:    server.URL + "/v1",
+	}
+	entry, err := logical.StorageEntryJSON(configPath, config)
+	require.NoError(t, err)
+	require.NoError(t, storage.Put(ctx, entry))
+
+	// First rotation: revocation of "old-key-1" fails.
+	_, err = b.rotateAdminAPIKey(ctx, storage)
+	require.Error(t, err)
+	first, err := storage.Get(ctx, pendingRevocationPath("old-key-1"))
+	require.NoError(t, err)
+	require.NotNil(t, first, "first stale key should be recorded")
+	assert.Equal(t, "old-key-1", string(first.Value))
+
+	// Config now holds "new-key-1". Second rotation: revocation of it also fails.
+	_, err = b.rotateAdminAPIKey(ctx, storage)
+	require.Error(t, err)
+	second, err := storage.Get(ctx, pendingRevocationPath("new-key-1"))
+	require.NoError(t, err)
+	require.NotNil(t, second, "second stale key should be recorded under its own path")
+
+	// The first record must survive the second failure.
+	stillThere, err := storage.Get(ctx, pendingRevocationPath("old-key-1"))
+	require.NoError(t, err)
+	require.NotNil(t, stillThere, "first stale key must not be overwritten by the second failure")
 }

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -52,6 +52,9 @@ func TestValidateAPIEndpoint(t *testing.T) {
 		{"empty string", "", true, "valid URL"},
 		{"just a path", "/v1", true, "http or https"},
 		{"missing host", "https:///v1", true, "host"},
+		{"userinfo", "https://user:pass@api.openai.com/v1", true, "userinfo"},
+		{"query string", "https://api.openai.com/v1?foo=bar", true, "query"},
+		{"fragment", "https://api.openai.com/v1#fragment", true, "fragment"},
 	}
 
 	for _, tt := range tests {

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -25,53 +24,39 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Item 1: SSRF / api_endpoint validation
+// Item 1: api_endpoint URL validation
 // ---------------------------------------------------------------------------
 
 func TestValidateAPIEndpoint(t *testing.T) {
 	tests := []struct {
-		name         string
-		endpoint     string
-		allowPrivate bool
-		wantError    bool
-		errContains  string
+		name        string
+		endpoint    string
+		wantError   bool
+		errContains string
 	}{
 		// Valid
-		{"openai production endpoint", "https://api.openai.com/v1", false, false, ""},
-		{"custom https hostname", "https://proxy.example.com/v1", false, false, ""},
-		{"https with port", "https://api.openai.com:443/v1", false, false, ""},
-		{"http loopback by IP", "http://127.0.0.1:8080/v1", false, false, ""},
-		{"http loopback by hostname", "http://localhost:9090/v1", false, false, ""},
+		{"openai production endpoint", "https://api.openai.com/v1", false, ""},
+		{"custom https hostname", "https://proxy.example.com/v1", false, ""},
+		{"https with port", "https://api.openai.com:443/v1", false, ""},
+		{"http loopback by IP", "http://127.0.0.1:8080/v1", false, ""},
+		{"http private IP", "http://10.0.0.1/v1", false, ""},
+		{"https private IP", "https://10.0.0.1/v1", false, ""},
+		{"https link-local IP", "https://169.254.169.254/latest/meta-data", false, ""},
 
 		// Invalid scheme
-		{"ftp scheme", "ftp://api.openai.com/v1", false, true, "https"},
-		{"no scheme", "api.openai.com/v1", false, true, "valid URL"},
-
-		// http with non-loopback is rejected
-		{"http public IP", "http://1.2.3.4/v1", false, true, "loopback"},
-		{"http public hostname", "http://api.openai.com/v1", false, true, "loopback"},
-		{"http private IP", "http://10.0.0.1/v1", false, true, "loopback"},
-
-		// SSRF: private / link-local literals
-		{"AWS metadata service", "https://169.254.169.254/latest/meta-data", false, true, "link-local"},
-		{"RFC1918 10.x", "https://10.0.0.1/", false, true, "private"},
-		{"RFC1918 172.16.x", "https://172.16.0.1/", false, true, "private"},
-		{"RFC1918 192.168.x", "https://192.168.1.1/", false, true, "private"},
-		{"IPv6 link-local", "https://[fe80::1]/", false, true, "link-local"},
-
-		// Opt-in override
-		{"private allowed when opted in", "https://10.0.0.1/v1", true, false, ""},
-		{"metadata allowed when opted in", "https://169.254.169.254/", true, false, ""},
+		{"ftp scheme", "ftp://api.openai.com/v1", true, "http or https"},
+		{"file scheme", "file:///tmp/openai", true, "http or https"},
+		{"no scheme", "api.openai.com/v1", true, "valid URL"},
 
 		// Malformed
-		{"empty string", "", false, true, "valid URL"},
-		{"just a path", "/v1", false, true, "https"},
-		{"missing hostname", "https:///v1", false, true, "hostname"},
+		{"empty string", "", true, "valid URL"},
+		{"just a path", "/v1", true, "http or https"},
+		{"missing hostname", "https:///v1", true, "hostname"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateAPIEndpoint(tt.endpoint, tt.allowPrivate)
+			err := validateAPIEndpoint(tt.endpoint)
 			if tt.wantError {
 				require.Error(t, err, "expected error for endpoint %q", tt.endpoint)
 				if tt.errContains != "" {
@@ -84,63 +69,17 @@ func TestValidateAPIEndpoint(t *testing.T) {
 	}
 }
 
-// TestCheckDialAddress verifies the dial-time guard that closes the gap a
-// hostname-only validation leaves open: a name that resolves to an internal IP.
-func TestCheckDialAddress(t *testing.T) {
-	c := NewClient("k", hclog.NewNullLogger())
-
-	// Private and link-local resolved addresses are rejected by default.
-	for _, addr := range []string{"10.0.0.1:443", "192.168.1.1:443", "169.254.169.254:80", "[fe80::1]:443"} {
-		require.Error(t, c.checkDialAddress(addr), "expected %q to be blocked", addr)
-	}
-
-	// Loopback and public addresses are allowed.
-	for _, addr := range []string{"127.0.0.1:8080", "[::1]:8080", "1.2.3.4:443"} {
-		require.NoError(t, c.checkDialAddress(addr), "expected %q to be allowed", addr)
-	}
-
-	// Opt-in relaxes the guard for private addresses.
-	c.allowPrivateEndpoint = true
-	require.NoError(t, c.checkDialAddress("10.0.0.1:443"))
-}
-
-// TestDialGuard_BlocksPrivateAtTransport drives a real request through the
-// guarded transport to prove the resolved-IP check fires at dial time, even
-// when the endpoint bypassed config-write validation.
-func TestDialGuard_BlocksPrivateAtTransport(t *testing.T) {
-	c := NewClient("k", hclog.NewNullLogger())
-	// Simulate a hostname that resolved to a private IP by assigning the
-	// endpoint directly, bypassing SetConfig validation.
-	c.apiEndpoint = "https://10.0.0.1"
-
-	_, err := c.doRequest(context.Background(), http.MethodGet, "/v1/models", nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "private or link-local")
-
-	// With the opt-in flag the guard no longer blocks; the request fails for a
-	// different reason (no server listening / timeout), not the SSRF guard. Use
-	// a short context so the unreachable dial does not wait for the full client
-	// timeout.
-	c.allowPrivateEndpoint = true
-	shortCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	_, err = c.doRequest(shortCtx, http.MethodGet, "/v1/models", nil)
-	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "private or link-local")
-}
-
-// TestSSRF_PrivateEndpointRejectedAtConfig verifies end-to-end rejection at
-// config-write time.
-func TestSSRF_PrivateEndpointRejectedAtConfig(t *testing.T) {
+// TestInvalidEndpointRejectedAtConfig verifies end-to-end URL syntax
+// validation at config-write time.
+func TestInvalidEndpointRejectedAtConfig(t *testing.T) {
 	b := getTestBackend(t)
 	ctx := context.Background()
 	schema := b.pathAdminConfig()[1].Fields
 
 	for _, ep := range []string{
-		"http://10.0.0.1/v1",
-		"https://192.168.1.1/v1",
-		"https://169.254.169.254/latest/meta-data",
 		"ftp://api.openai.com/v1",
+		"api.openai.com/v1",
+		"https:///v1",
 	} {
 		t.Run(ep, func(t *testing.T) {
 			req := &logical.Request{
@@ -163,35 +102,6 @@ func TestSSRF_PrivateEndpointRejectedAtConfig(t *testing.T) {
 			require.NotNil(t, resp)
 			assert.True(t, resp.IsError(), "expected error response for endpoint %q", ep)
 		})
-	}
-}
-
-// TestConfig_AllowPrivateEndpoint confirms the opt-in flag permits a private
-// endpoint at config-write time.
-func TestConfig_AllowPrivateEndpoint(t *testing.T) {
-	b := getTestBackend(t)
-	ctx := context.Background()
-
-	req := &logical.Request{
-		Operation:  logical.UpdateOperation,
-		Path:       "config",
-		Storage:    &logical.InmemStorage{},
-		MountPoint: TestMountPoint,
-	}
-	fd := &framework.FieldData{
-		Raw: map[string]interface{}{
-			"admin_api_key":          "test-key",
-			"admin_api_key_id":       "test-key-id",
-			"organization_id":        "org-123",
-			"api_endpoint":           "https://10.0.0.1/v1",
-			"allow_private_endpoint": true,
-		},
-		Schema: b.pathAdminConfig()[1].Fields,
-	}
-	resp, err := b.pathConfigWrite(ctx, req, fd)
-	require.NoError(t, err)
-	if resp != nil {
-		assert.False(t, resp.IsError(), "private endpoint should be accepted when opted in")
 	}
 }
 

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -8,7 +8,6 @@ package openaisecrets
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -300,68 +299,4 @@ func TestConfigDelete_DeregistersRotationJob(t *testing.T) {
 	_, err = b.pathConfigDelete(ctx, req, nil)
 	require.NoError(t, err)
 	assert.True(t, sv.deregisterCalled, "expected rotation job to be deregistered on config delete")
-}
-
-// ---------------------------------------------------------------------------
-// Item 4: failed revocation records each stale key under a per-ID path
-// ---------------------------------------------------------------------------
-
-// TestRotation_PendingRevocationPerKey verifies that when admin key revocation
-// fails, the stale key ID is recorded under a per-ID storage path, and that two
-// consecutive failures retain two distinct records rather than overwriting.
-func TestRotation_PendingRevocationPerKey(t *testing.T) {
-	var keyCounter int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/admin_api_keys"):
-			keyCounter++
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprintf(w,
-				`{"object":"admin_api_key","id":"new-key-%d","name":"n","value":"sk-new-%d","created_at":1}`,
-				keyCounter, keyCounter)
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/admin_api_keys"):
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data":[]}`))
-		case r.Method == http.MethodDelete:
-			// Simulate revocation failure.
-			w.WriteHeader(http.StatusInternalServerError)
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	b := getTestBackend(t)
-	ctx := context.Background()
-	storage := &logical.InmemStorage{}
-
-	config := &openaiConfig{
-		AdminAPIKey:    "old-secret",
-		AdminAPIKeyID:  "old-key-1",
-		OrganizationID: "org-123",
-		APIEndpoint:    server.URL + "/v1",
-	}
-	entry, err := logical.StorageEntryJSON(configPath, config)
-	require.NoError(t, err)
-	require.NoError(t, storage.Put(ctx, entry))
-
-	// First rotation: revocation of "old-key-1" fails.
-	_, err = b.rotateAdminAPIKey(ctx, storage)
-	require.Error(t, err)
-	first, err := storage.Get(ctx, pendingRevocationPath("old-key-1"))
-	require.NoError(t, err)
-	require.NotNil(t, first, "first stale key should be recorded")
-	assert.Equal(t, "old-key-1", string(first.Value))
-
-	// Config now holds "new-key-1". Second rotation: revocation of it also fails.
-	_, err = b.rotateAdminAPIKey(ctx, storage)
-	require.Error(t, err)
-	second, err := storage.Get(ctx, pendingRevocationPath("new-key-1"))
-	require.NoError(t, err)
-	require.NotNil(t, second, "second stale key should be recorded under its own path")
-
-	// The first record must survive the second failure.
-	stillThere, err := storage.Get(ctx, pendingRevocationPath("old-key-1"))
-	require.NoError(t, err)
-	require.NotNil(t, stillThere, "first stale key must not be overwritten by the second failure")
 }

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -404,9 +404,9 @@ func TestRotation_PendingRevocationPerKey(t *testing.T) {
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/admin_api_keys"):
 			keyCounter++
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(
+			_, _ = fmt.Fprintf(w,
 				`{"object":"admin_api_key","id":"new-key-%d","name":"n","value":"sk-new-%d","created_at":1}`,
-				keyCounter, keyCounter)))
+				keyCounter, keyCounter)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/admin_api_keys"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"data":[]}`))

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -283,7 +284,7 @@ func TestConfigDelete_DeregistersRotationJob(t *testing.T) {
 		OrganizationID: "org-123",
 		APIEndpoint:    DefaultAPIEndpoint,
 	}
-	config.RotationPeriod = 24 * 3600
+	config.RotationPeriod = 24 * time.Hour
 	require.True(t, config.ShouldRegisterRotationJob())
 	entry, err := logical.StorageEntryJSON(configPath, config)
 	require.NoError(t, err)

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -36,7 +36,7 @@ func TestValidateAPIEndpoint(t *testing.T) {
 	}{
 		// Valid
 		{"openai production endpoint", "https://api.openai.com/v1", false, ""},
-		{"custom https hostname", "https://proxy.example.com/v1", false, ""},
+		{"custom https host", "https://proxy.example.com/v1", false, ""},
 		{"https with port", "https://api.openai.com:443/v1", false, ""},
 		{"http loopback by IP", "http://127.0.0.1:8080/v1", false, ""},
 		{"http private IP", "http://10.0.0.1/v1", false, ""},
@@ -51,7 +51,7 @@ func TestValidateAPIEndpoint(t *testing.T) {
 		// Malformed
 		{"empty string", "", true, "valid URL"},
 		{"just a path", "/v1", true, "http or https"},
-		{"missing hostname", "https:///v1", true, "hostname"},
+		{"missing host", "https:///v1", true, "host"},
 	}
 
 	for _, tt := range tests {

--- a/plugin/security_fixes_test.go
+++ b/plugin/security_fixes_test.go
@@ -203,6 +203,7 @@ func TestValidateNameTemplate(t *testing.T) {
 	}{
 		{"default template", "vault-{{.RoleName}}-{{.RandomSuffix}}", false},
 		{"project name template", "{{.ProjectName}}-{{.RandomSuffix}}", false},
+		{"vault username template functions", "vault-{{.RoleName | truncate 4}}-{{random 8}}", false},
 		{"empty template", "", true},
 		{"broken syntax", "vault-{{.RoleName", true},
 		{"reserved word", "openai", true},

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -15,22 +15,59 @@ fi
 # Check if we should run integration tests
 if [ "$1" == "--integration" ]; then
     echo -e "\n=== Running integration tests ==="
-    # Prompt for OpenAI admin key and org ID
+    cat <<'EOF'
+
+These tests run against the live OpenAI API and create real (short-lived)
+service accounts in a test project. You will need three values:
+
+  1. Admin API Key   (OPENAI_ADMIN_API_KEY)
+  2. Organization ID (OPENAI_ORG_ID, starts with "org-")
+  3. Test Project ID (OPENAI_TEST_PROJECT_ID, starts with "proj_")
+
+Tip: export these as environment variables to skip the prompts next time.
+
+EOF
+
+    # Prompt for any values that were not provided via the environment.
     if [ -z "$OPENAI_ADMIN_API_KEY" ]; then
-        read -s -p "Enter your OpenAI Admin API Key: " OPENAI_ADMIN_API_KEY
+        echo "→ Create an Admin API Key: https://platform.openai.com/settings/organization/admin-keys"
+        read -r -s -p "  Enter your OpenAI Admin API Key: " OPENAI_ADMIN_API_KEY
         echo
     fi
     if [ -z "$OPENAI_ORG_ID" ]; then
-        read -p "Enter your OpenAI Organization ID: " OPENAI_ORG_ID
+        echo "→ Find your Organization ID: https://platform.openai.com/settings/organization/general"
+        read -r -p "  Enter your OpenAI Organization ID: " OPENAI_ORG_ID
     fi
     if [ -z "$OPENAI_TEST_PROJECT_ID" ]; then
-        read -p "Enter your OpenAI Test Project ID: " OPENAI_TEST_PROJECT_ID
+        echo "→ Find a Project ID: https://platform.openai.com/settings/organization/projects"
+        read -r -p "  Enter your OpenAI Test Project ID: " OPENAI_TEST_PROJECT_ID
     fi
-    # Check if required environment variables are set
-    if [ -z "$OPENAI_ADMIN_API_KEY" ] || [ -z "$OPENAI_ORG_ID" ] || [ -z "$OPENAI_TEST_PROJECT_ID" ]; then
-        echo "❌ ERROR: OPENAI_ADMIN_API_KEY, OPENAI_ORG_ID, and OPENAI_TEST_PROJECT_ID are required for integration tests."
+
+    # Validate that every required value is present, reporting each one that is missing.
+    MISSING_VARS=()
+    [ -z "$OPENAI_ADMIN_API_KEY" ] && MISSING_VARS+=("OPENAI_ADMIN_API_KEY")
+    [ -z "$OPENAI_ORG_ID" ] && MISSING_VARS+=("OPENAI_ORG_ID")
+    [ -z "$OPENAI_TEST_PROJECT_ID" ] && MISSING_VARS+=("OPENAI_TEST_PROJECT_ID")
+    if [ ${#MISSING_VARS[@]} -ne 0 ]; then
+        echo "❌ ERROR: Missing required value(s): ${MISSING_VARS[*]}"
+        echo "   Set them as environment variables or enter them when prompted, then re-run."
         exit 1
     fi
+
+    # Catch common copy/paste mistakes early with friendly format warnings.
+    case "$OPENAI_ADMIN_API_KEY" in
+        sk-admin*) ;;
+        *) echo "⚠️  Warning: OPENAI_ADMIN_API_KEY usually starts with 'sk-admin'. Did you paste an Admin API Key?" ;;
+    esac
+    case "$OPENAI_ORG_ID" in
+        org-*) ;;
+        *) echo "⚠️  Warning: OPENAI_ORG_ID usually starts with 'org-'. Got: $OPENAI_ORG_ID" ;;
+    esac
+    case "$OPENAI_TEST_PROJECT_ID" in
+        proj_*) ;;
+        *) echo "⚠️  Warning: OPENAI_TEST_PROJECT_ID usually starts with 'proj_'. Got: $OPENAI_TEST_PROJECT_ID" ;;
+    esac
+    echo "✅ Configuration collected. Starting Vault and running integration tests..."
     
     export VAULT_ADDR=http://127.0.0.1:8200
     export VAULT_TOKEN=root
@@ -61,20 +98,36 @@ if [ "$1" == "--integration" ]; then
     # Get the admin API key ID using the OpenAI API (match prefix and suffix)
     KEY_PREFIX="${OPENAI_ADMIN_API_KEY:0:8}"
     KEY_SUFFIX="${OPENAI_ADMIN_API_KEY: -4}"
-    ADMIN_API_KEY_ID=$(curl -s https://api.openai.com/v1/organization/admin_api_keys \
+    ADMIN_KEYS_RESPONSE=$(curl -s https://api.openai.com/v1/organization/admin_api_keys \
       -H "Authorization: Bearer $OPENAI_ADMIN_API_KEY" \
-      -H "Content-Type: application/json" | \
+      -H "Content-Type: application/json")
+    # If the response has no .data array, the API returned an error (bad key,
+    # insufficient permissions, etc.). Surface that message instead of a generic one.
+    if ! echo "$ADMIN_KEYS_RESPONSE" | jq -e '.data' > /dev/null 2>&1; then
+      echo "❌ ERROR: OpenAI API did not return an admin key list."
+      echo "   Check that OPENAI_ADMIN_API_KEY is a valid Admin API Key with organization access."
+      echo "   API response:"
+      echo "$ADMIN_KEYS_RESPONSE" | jq '.' 2>/dev/null || echo "$ADMIN_KEYS_RESPONSE"
+      exit 1
+    fi
+    ADMIN_API_KEY_ID=$(echo "$ADMIN_KEYS_RESPONSE" | \
       jq -r --arg prefix "$KEY_PREFIX" --arg suffix "$KEY_SUFFIX" \
         '.data[] | select(.redacted_value | startswith($prefix) and endswith($suffix)) | .id' | head -n1)
     if [ -z "$ADMIN_API_KEY_ID" ]; then
-      echo "❌ ERROR: Could not determine admin API key ID from OpenAI API."
+      echo "❌ ERROR: Could not find an admin API key matching the provided OPENAI_ADMIN_API_KEY."
+      echo "   The key is valid but its ID was not found in the organization's admin key list."
       exit 1
     fi
     # Configure the plugin with both admin_api_key and admin_api_key_id
     vault write openai/config admin_api_key="$OPENAI_ADMIN_API_KEY" admin_api_key_id="$ADMIN_API_KEY_ID" organization_id="$OPENAI_ORG_ID" rotation_period=5s
     # Rotate the OpenAI admin API key (simulate rotation)
     vault read openai/config
+    echo ".: Check the admin key is being rotated here: https://platform.openai.com/settings/organization/admin-keys"
+
+    # Echo each command below so the output shows exactly what ran.
+    set -x
     sleep 20
+ 
     vault path-help openai
     vault path-help openai/config
     vault path-help openai/config/rotate
@@ -91,9 +144,14 @@ if [ "$1" == "--integration" ]; then
 
     # Issue dynamic credentials
     vault path-help openai/creds/test-role
-    vault read openai/creds/test-role
 
-    sleep 15
+    echo ".: Check the project keys are being created here: https://platform.openai.com/api-keys"
+    for i in 1 2 3; do
+        vault read openai/creds/test-role
+        [ "$i" -lt 3 ] && sleep 7
+    done
+    # Stop echoing commands.
+    set +x
 fi
 
 


### PR DESCRIPTION
## Summary

This PR re-implements the security and hardening findings we accepted from #7, with adjusted severities based on the [HashiCorp Vault threat model](https://developer.hashicorp.com/vault/docs/internals/security) and the [plugin development guidance](https://developer.hashicorp.com/vault/docs/plugins/plugin-development). The original audit was contributed by Tobias Macey (@blarghmatey) in #7 — thank you.

After review, the `api_endpoint` changes were intentionally scoped down. Because `openai/config` is an administrative path, the plugin does **not** try to enforce network egress policy. It now only performs simple URL validation; operators who need stronger endpoint restrictions should use Vault ACL parameter constraints and network egress controls.

## Accepted fixes

- **Data race on `b.client`** — all reads snapshot under `RLock`; all writes (`initialize`, config write/delete, rotation) hold `Lock`; `configuredClient` lazy-loads and snapshots the client without nil panics if config is deleted concurrently.
- **Panic in `dynamicCredsRevoke`** — bare `.(string)` assertions replaced with comma-ok checks returning descriptive errors.
- **Config delete leaked rotation job** — `pathConfigDelete` now deregisters the associated rotation job before deleting stored config. Rotation jobs are managed separately from plugin storage, so leaving one registered could cause later rotation attempts after config removal.
- **Admin key rotation failure handling** — if previous-key revocation fails after the new key is validated and persisted, the function returns an error and logs that the old key may still be active, without logging admin key IDs. This PR does not persist stale-key records because that requires retry/list/delete lifecycle support; deferred cleanup is tracked in #11.
- **Admin key prefix warning** — config writes log a warning when `admin_api_key` does not start with the expected OpenAI admin key prefix (`sk-admin`), without logging the key value.
- **Outbound OpenAI response handling** — bounds plugin reads of external OpenAI response bodies to 1 MiB and avoids echoing raw non-standard error bodies into logs or returned errors. This protects the plugin's outbound dependency path; Vault listener JSON limits protect inbound Vault API requests separately.
- **Modular bias in `generateRandomString`** — rejection sampling.
- **Service account name templates** — switched from custom `text/template` handling to Vault's username templating helper and validate templates at role-write time. This enables documented functions such as `random`, `truncate`, `truncate_sha256`, `lowercase`, `uppercase`, `replace`, `timestamp`, `unix_time`, `uuid`, `sha256`, and `base64`.
- **Dead `api_keys/` storage** — removed `storeServiceAccountInfo` and call sites.
- **Rotation key name leaked timing** — random 8-character suffix.
- **Bonus** — removed the unused `managedUsers` field.

## Endpoint validation (item 1)

This PR keeps only a simple, fail-fast syntax check for `api_endpoint`:

- must be a valid URL;
- scheme must be `http` or `https`;
- host must be present (hostname or IP address);
- userinfo, query strings, and fragments are rejected so the configured value remains a clean base URL for client request construction.

It does **not** block private or link-local addresses, does **not** add a dial-time IP guard, and does **not** add an `allow_private_endpoint` flag. Those controls were removed because they were not a real authorization boundary: a principal who can write `api_endpoint` could also enable the bypass flag. The right layers for strict egress restrictions are Vault policy and the network.

Example policy for pinning the endpoint to the public OpenAI API:

```hcl
path "openai/config" {
  capabilities = ["create", "update"]

  allowed_parameters = {
    "api_endpoint" = ["https://api.openai.com/v1"]
    "*"            = []
  }
}
```

Network controls such as firewall rules, security groups, service mesh egress policy, and IMDSv2 hop-limit are still recommended where SSRF risk matters.

## Tests

`plugin/security_fixes_test.go` and existing dynamic-credential tests add regression coverage for endpoint URL validation, the 1 MiB outbound response-body cap, safe revoke assertions, RNG uniformity, Vault username-template functions, role-write template rejection, and config-delete deregistration.

Local verification:

- `make check-fmt`: pass
- `go vet ./...`: pass
- `go test -race ./...`: pass
- `golangci-lint v2.12.2 run --timeout=5m`: 0 issues
- `gosec -quiet ./plugin/`: 0 issues

## Follow-up

Optional bounded overlap and deferred revocation cleanup for admin key rotation is tracked separately in #11. The OpenAI spec permits multiple active admin keys but provides no server-side expiry for admin keys, so a correct implementation needs plugin-managed records with retry and cleanup lifecycle.